### PR TITLE
Set up ember-page-title

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>FrontendContactHub</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,3 +1,5 @@
+{{page-title "ContactHub"}}
+
 <AuMainHeader
     @brandLink="https://www.vlaanderen.be/nl"
     @homeRoute="index"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12703,6 +12703,15 @@
         }
       }
     },
+    "ember-page-title": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ember-page-title/-/ember-page-title-6.2.2.tgz",
+      "integrity": "sha512-YTXA+cylZrh9zO0zwjlaAGReT2MVOxAMnVO1OOygFrs1JBs4D6CKV3tImoilg3AvIXFBeJfFNNUbJOdRd9IGGg==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.23.1"
+      }
+    },
     "ember-power-select": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/ember-power-select/-/ember-power-select-4.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-modifier": "^2.1.1",
+    "ember-page-title": "^6.2.2",
     "ember-power-select": "^4.1.5",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",


### PR DESCRIPTION
Normally this is already installed in 3.24+ not sure why it wasn't.