### PR TITLE
Add "skeleton loading" to the people search page

### DIFF
--- a/app/controllers/people/index.js
+++ b/app/controllers/people/index.js
@@ -14,9 +14,23 @@ export default class PeopleIndexController extends Controller {
   @tracked familyName = '';
   @tracked organization = '';
 
+  get people() {
+    return this.model.loadPeopleTaskInstance.isFinished ?
+      this.model.loadPeopleTaskInstance.value :
+      this.model.loadedPeople;
+  }
+
+  get isLoading() {
+    return this.model.loadPeopleTaskInstance.isRunning;
+  }
+
+  get showTableLoader() {
+    return this.isLoading && !this.model.loadedPeople;
+  }
 
   @action
-  search() {
+  search(event) {
+    event.preventDefault();
     this.router.refresh();
   }
 }

--- a/app/templates/people/index.hbs
+++ b/app/templates/people/index.hbs
@@ -2,7 +2,10 @@
     <div class="au-c-main-container__sidebar">
         <div class="au-c-sidebar">
             <div class="au-c-sidebar__content au-o-box">
-                <div class="au-c-form">
+                <form
+                  {{on "submit" this.search}}
+                  class="au-c-form"
+                >
                     <p>
                       <AuLabel for="filter-given-name">Given name</AuLabel>
                       <AuInput id="filter-given-name" @width="block" @value={{this.givenName}} />
@@ -15,17 +18,23 @@
                       <AuLabel for="filter-organization">Organization</AuLabel>
                       <AuInput id="filter-organization" @width="block" @value={{this.organization}} />
                     </p>
-                    <AuButton @width="block" {{on "click" this.search}}>
+                    <AuButton
+                      @loading={{this.isLoading}}
+                      @disabled={{this.isLoading}}
+                      @width="block"
+                      type="submit"
+                    >
                         Search
                     </AuButton>
-                </div>
+                </form>
             </div>
         </div>
     </div>
     <div class="au-c-main-container__content">
         <div class="au-d-component-block">
             <AuDataTable
-              @content={{@model}}
+              @content={{this.people}}
+              @isLoading={{this.showTableLoader}}
               @noDataMessage="No person found"
               @page={{this.page}}
               @size={{this.size}}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.1",
+    "ember-concurrency": "^2.1.0",
     "ember-data": "~3.25.0",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.4",


### PR DESCRIPTION
Since the API calls take a while to finish, waiting for the model hook to finish isn't very user friendly.

This change makes sure the page instantly renders and shows a loading state instead.

This follows a similar pattern as described here: https://engineering.linkedin.com/blog/2016/12/ember-concurrency--or--how-i-learned-to-stop-worrying-and-love-t