### PR TITLE
Install ember-config-helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11092,6 +11092,16 @@
         }
       }
     },
+    "ember-config-helper": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ember-config-helper/-/ember-config-helper-0.1.3.tgz",
+      "integrity": "sha512-C4gPynSPKkedD5EqNq8oxb9KnLVHx2zRP3jIzai9Ua6hOfaStI+RGdC6t9gDAuQSr+lt8I8Qx0PUgBbP6yZlwA==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.23.1",
+        "ember-cli-htmlbars": "^5.3.2"
+      }
+    },
     "ember-data": {
       "version": "3.26.0",
       "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-3.26.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.1",
     "ember-concurrency": "^2.1.0",
+    "ember-config-helper": "^0.1.3",
     "ember-data": "~3.26.0",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.4",


### PR DESCRIPTION
Not used right now, but it will be useful when we need to link to the user manuals, or when configuring mail addresses. 