### PR TITLE
Prettier: Don't use single quotes for .hbs files

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,4 +2,12 @@
 
 module.exports = {
   singleQuote: true,
+  overrides: [
+    {
+      files: '*.hbs',
+      options: {
+        singleQuote: false,
+      },
+    },
+  ],
 };


### PR DESCRIPTION
Using prettier for .hbs files should now keep the double quotes.