### PR TITLE
Disable prototype extensions

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -22,10 +22,7 @@ module.exports = function (environment) {
         // Here you can enable experimental features on an ember canary build
         // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true
       },
-      EXTEND_PROTOTYPES: {
-        // Prevent Ember Data from overriding Date.parse.
-        Date: false,
-      },
+      EXTEND_PROTOTYPES: false,
     },
 
     APP: {


### PR DESCRIPTION
These shouldn't be needed in modern apps. If the array behavior is wanted it's better to create an ember array explicitly.

More information: https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/