### PR TITLE
Move the administrative unit breadcrumb to the parent page

### DIFF
--- a/app/templates/administrative-units/administrative-unit.hbs
+++ b/app/templates/administrative-units/administrative-unit.hbs
@@ -1,4 +1,11 @@
-<div class="au-c-main-container au-c-main-container__content--block">
+{{page-title @model.name}}
+{{breadcrumb
+  @model.name
+  route="administrative-units.administrative-unit"
+  model=@model.id
+}}
+
+<div class="au-c-main-container">
   <div class="au-c-main-container__sidebar">
       <div class="au-d-component-block au-c-sidebar">
         <ul class="au-c-list-navigation">
@@ -48,7 +55,7 @@
             </AuNavigationLink>
           </li>
         </ul>
-    </div> 
+    </div>
   </div>
   {{outlet}}
 </div>

--- a/app/templates/administrative-units/administrative-unit/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/index.hbs
@@ -1,10 +1,3 @@
-{{page-title @model.name}}
-{{breadcrumb
-  @model.name
-  route="administrative-units.administrative-unit"
-  model=@model.id
-}}
-
 <div class="au-c-main-container__content au-c-main-container__content--block">
   <div class="au-o-box au-d-component-block au-d-component-block--overflow au-o-flow">
     <div class="au-o-flow au-o-flow--tiny">


### PR DESCRIPTION
This makes sure the breadcrumb is visible on all subpages instead of only on the "core data" page.