### PR TITLE
Add an explicit inverse to the scope relationship

### DIFF
--- a/app/models/administrative-unit.js
+++ b/app/models/administrative-unit.js
@@ -3,7 +3,7 @@ import OrganizationModel from './organization';
 
 export default class AdministrativeUnitModel extends OrganizationModel {
   @belongsTo('administrative-unit-classification-code') classification;
-  @belongsTo('location') scope;
+  @belongsTo('location', { inverse: 'administrativeUnit' }) scope;
   @hasMany('governing-body', { inverse: 'administrativeUnit' }) governingBodies;
   @hasMany('local-involvement') involvedBoards;
 }


### PR DESCRIPTION
It might be a good idea to do this for _all_ relationships that have an inverse. I think ember data is moving towards pushing people to always make that explicit. But for now we'll do it if we run into issues I guess :smile:.