### PR TITLE
Refactor/card columns

### DIFF
--- a/app/components/card-columns.hbs
+++ b/app/components/card-columns.hbs
@@ -1,0 +1,16 @@
+<div class="card-columns" ...attributes>
+  <div class="card-columns__column">
+    {{#if @itemComponent}}
+      {{yield (component @itemComponent) to="left"}}
+    {{else}}
+      {{yield to="left"}}
+    {{/if}}
+  </div>
+  <div class="card-columns__column">
+    {{#if @itemComponent}}
+      {{yield (component @itemComponent) to="right"}}
+    {{else}}
+      {{yield to="right"}}
+    {{/if}}
+  </div>
+</div>

--- a/app/components/data-card.hbs
+++ b/app/components/data-card.hbs
@@ -9,7 +9,10 @@
 
   <dl class="data-card__card">
     {{yield
-      (hash Grid=(component 'card-grid' itemComponent=(component 'data-card/item')))
+      (hash
+        Grid=(component "card-grid" itemComponent=(component "data-card/item" isGrid=true))
+        Columns=(component "card-columns" itemComponent=(component "data-card/item"))
+      )
       to="card"
     }}
   </dl>

--- a/app/components/data-card.hbs
+++ b/app/components/data-card.hbs
@@ -9,7 +9,7 @@
 
   <dl class="data-card__card">
     {{yield
-      (component 'card-grid' itemComponent=(component 'data-card/item'))
+      (hash Grid=(component 'card-grid' itemComponent=(component 'data-card/item')))
       to="card"
     }}
   </dl>

--- a/app/components/data-card/item.hbs
+++ b/app/components/data-card/item.hbs
@@ -1,12 +1,15 @@
-<div class="data-card-item card-grid-item {{if @alignTop "card-grid-item--align-top"}}" ...attributes>
+<div
+  class="data-card-item card-item {{if @alignTop "card-grid-item--align-top"}} {{if @isGrid "card-grid-item"}}"
+  ...attributes
+>
   {{#if (has-block "label")}}
-    <dt class="data-card-item__label card-grid-item__label">
+    <dt class="data-card-item__label card-item__label">
       {{yield to="label"}}
     </dt>
   {{/if}}
 
   {{#if (has-block "content")}}
-    <dd class="data-card-item__content card-grid-item__content">
+    <dd class="data-card-item__content card-item__content">
       {{yield to="content"}}
     </dd>
   {{/if}}

--- a/app/components/edit-card.hbs
+++ b/app/components/edit-card.hbs
@@ -9,7 +9,7 @@
 
   <div class="edit-card__card">
     {{yield
-      (component 'card-grid' itemComponent=(component 'edit-card/item'))
+      (hash Grid=(component 'card-grid' itemComponent=(component 'edit-card/item')))
       to="card"
     }}
   </div>

--- a/app/components/edit-card.hbs
+++ b/app/components/edit-card.hbs
@@ -9,7 +9,10 @@
 
   <div class="edit-card__card">
     {{yield
-      (hash Grid=(component 'card-grid' itemComponent=(component 'edit-card/item')))
+      (hash
+        Grid=(component "card-grid" itemComponent=(component "edit-card/item" isGrid=true))
+        Columns=(component "card-columns" itemComponent=(component "edit-card/item"))
+      )
       to="card"
     }}
   </div>

--- a/app/components/edit-card/item.hbs
+++ b/app/components/edit-card/item.hbs
@@ -1,8 +1,11 @@
-<div class="edit-card-item card-grid-item {{if @alignTop "card-grid-item--align-top"}}" ...attributes>
+<div
+  class="edit-card-item card-item {{if @alignTop "card-item--align-top"}} {{if @isGrid "card-grid-item"}}"
+  ...attributes
+>
   {{#if (has-block "label")}}
-    <div class="card-grid-item__label">
+    <div class="card-item__label">
       <AuLabel
-        class="edit-card-item__label card-grid-item__label {{@labelClass}}"
+        class="edit-card-item__label card-item__label {{@labelClass}}"
         for={{@labelFor}}
       >
         {{yield to="label"}}
@@ -11,7 +14,7 @@
   {{/if}}
 
   {{#if (has-block "content")}}
-    <div class="edit-card-item__content card-grid-item__content">
+    <div class="edit-card-item__content card-item__content">
       {{yield to="content"}}
     </div>
   {{/if}}

--- a/app/styles/components/_cards.scss
+++ b/app/styles/components/_cards.scss
@@ -2,29 +2,43 @@
   margin-bottom: $au-unit-tiny;
 }
 
-// Grid
+// grid
 .card-grid {
   display: flex;
   flex-wrap: wrap;
 }
 
 .card-grid-item {
-  align-items: center;
-  display: flex;
-  padding: $au-unit-tiny;
   width: 50%;
 }
 
-.card-grid-item--align-top {
+// columns
+.card-columns {
+  display: flex;
+}
+
+.card-columns__column {
+  width: 50%;
+}
+
+
+// card item
+.card-item {
+  align-items: center;
+  display: flex;
+  padding: $au-unit-tiny;
+}
+
+.card-item--align-top {
   align-items: flex-start;
 }
 
-.card-grid-item__label {
+.card-item__label {
   flex-basis: 20rem; // This has to be wide enough to fit all labels properly
   flex-shrink: 0;
 }
 
-.card-grid-item__content {
+.card-item__content {
   flex-shrink: 1;
   flex-grow: 1;
 }
@@ -50,4 +64,3 @@
 .edit-card-item__label {
   margin-bottom: 0;
 }
-

--- a/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
@@ -15,8 +15,8 @@
       <div class="au-o-flow au-o-flow--large">
         <EditCard>
           <:title>Bestuurseenheid</:title>
-          <:card as |Grid|>
-            <Grid as |Item|>
+          <:card as |Card|>
+            <Card.Grid as |Item|>
               <Item @labelFor="worship-service-name">
                 <:label>Naam eredienst</:label>
                 <:content>
@@ -45,8 +45,8 @@
                   </PowerSelect>
                 </:content>
               </Item>
-            </Grid>
-            <Grid as |Item|>
+            </Card.Grid>
+            <Card.Grid as |Item|>
               <Item>
                 <:label>Type bestuur</:label>
                 <:content>
@@ -62,8 +62,8 @@
                   </PowerSelect>
                 </:content>
               </Item>
-            </Grid>
-            <Grid as |Item|>
+            </Card.Grid>
+            <Card.Grid as |Item|>
               <Item @labelFor="recognized-worship-type-select">
                 <:label>Type eredienst</:label>
                 <:content>
@@ -75,14 +75,14 @@
                   />
                 </:content>
               </Item>
-            </Grid>
+            </Card.Grid>
             {{#if
               (eq
                 @model.administrativeUnit.constructor.modelName
                 "worship-service"
               )
             }}
-              <Grid as |Item|>
+              <Card.Grid as |Item|>
                 <Item @labelFor="denomination">
                   <:label>Strekking</:label>
                   <:content>
@@ -93,8 +93,8 @@
                     />
                   </:content>
                 </Item>
-              </Grid>
-              <Grid as |Item|>
+              </Card.Grid>
+              <Card.Grid as |Item|>
                 <Item>
                   <:label>Grensoverschrijvend</:label>
                   <:content>
@@ -125,9 +125,9 @@
                     />
                   </:content>
                 </Item>
-              </Grid>
+              </Card.Grid>
             {{/if}}
-            <Grid as |Item|>
+            <Card.Grid as |Item|>
               <Item @labelFor="administrative-unit-scope">
                 <:label>Werkingsgebied</:label>
                 <:content>
@@ -154,14 +154,14 @@
                   <:content></:content>
                 </Item>
               {{/each}}
-            </Grid>
+            </Card.Grid>
           </:card>
         </EditCard>
 
         <EditCard>
           <:title>Primaire contactgegevens</:title>
-          <:card as |Grid|>
-            <Grid as |Item|>
+          <:card as |Card|>
+            <Card.Grid as |Item|>
               <Item @labelFor="primary-site-address-street-name">
                 <:label>Straat</:label>
                 <:content>
@@ -248,20 +248,20 @@
                   />
                 </:content>
               </Item>
-            </Grid>
+            </Card.Grid>
           </:card>
         </EditCard>
 
         <EditCard>
           <:title>Gerelateerde organisaties</:title>
-          <:card as |Grid|>
+          <:card as |Card|>
             {{#if
               (eq
                 @model.administrativeUnit.constructor.modelName
                 "worship-service"
               )
             }}
-              <Grid as |Item|>
+              <Card.Grid as |Item|>
                 <Item>
                   <:label>Centraal bestuur</:label>
                   <:content>
@@ -273,7 +273,7 @@
                     />
                   </:content>
                 </Item>
-              </Grid>
+              </Card.Grid>
             {{/if}}
             {{#if
               (eq
@@ -282,7 +282,7 @@
               )
             }}
               {{#each @model.administrativeUnit.subOrganizations as |worship|}}
-                <Grid as |Item|>
+                <Card.Grid as |Item|>
                   <Item>
                     {{! TODO: Enable to edit the list of worship services that are linked to central worship service }}
                     <:label>Bestuur van de eredienst</:label>
@@ -290,10 +290,10 @@
                       {{worship.name}}
                     </:content>
                   </Item>
-                </Grid>
+                </Card.Grid>
               {{/each}}
             {{/if}}
-            <Grid as |Item|>
+            <Card.Grid as |Item|>
               <Item>
                 <:label>Representatief orgaan</:label>
                 <:content>
@@ -305,7 +305,7 @@
                   />
                 </:content>
               </Item>
-            </Grid>
+            </Card.Grid>
           </:card>
         </EditCard>
 

--- a/app/templates/administrative-units/administrative-unit/core-data/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/core-data/index.hbs
@@ -25,8 +25,8 @@
 
     <DataCard>
       <:title>Bestuurseenheid</:title>
-      <:card as |Grid|>
-        <Grid as |Item|>
+      <:card as |Card|>
+        <Card.Grid as |Item|>
           <Item>
             <:label>Naam eredienst</:label>
             <:content>{{@model.administrativeUnit.name}}</:content>
@@ -39,8 +39,8 @@
               />
             </:content>
           </Item>
-        </Grid>
-        <Grid as |Item|>
+        </Card.Grid>
+        <Card.Grid as |Item|>
           <Item>
             <:label>Type bestuur</:label>
             <:content>
@@ -59,37 +59,37 @@
               </:content>
             </Item>
           {{/if}}
-        </Grid>
-        <Grid as |Item|>
+        </Card.Grid>
+        <Card.Grid as |Item|>
           <Item>
             <:label>Type eredienst</:label>
             <:content
             >{{@model.administrativeUnit.recognizedWorshipType.label}}</:content>
           </Item>
-        </Grid>
+        </Card.Grid>
 
         {{#if @model.administrativeUnit.denomination}}
-          <Grid as |Item|>
+          <Card.Grid as |Item|>
             <Item>
               <:label>Strekking</:label>
               <:content>{{@model.administrativeUnit.denomination}}</:content>
             </Item>
-          </Grid>
+          </Card.Grid>
         {{/if}}
 
         {{#if
           (eq @model.administrativeUnit.constructor.modelName "worship-service")
         }}
-          <Grid as |Item|>
+          <Card.Grid as |Item|>
             <Item>
               <:label>Grensoverschrijdend</:label>
               <:content
               >{{@model.administrativeUnit.crossBorderNominal}}</:content>
             </Item>
-          </Grid>
+          </Card.Grid>
         {{/if}}
 
-        <Grid as |Item|>
+        <Card.Grid as |Item|>
           {{#if @model.administrativeUnit.scope.label}}
             <Item>
               <:label>Werkingsgebied</:label>
@@ -107,7 +107,7 @@
               <:content></:content>
             </Item>
           {{/each}}
-        </Grid>
+        </Card.Grid>
       </:card>
     </DataCard>
 
@@ -115,8 +115,8 @@
       <:title>
         Primaire contactgegevens
       </:title>
-      <:card as |Grid|>
-        <Grid as |Item|>
+      <:card as |Card|>
+        <Card.Grid as |Item|>
           <Item>
             <:label>Adres</:label>
             <:content>
@@ -149,7 +149,7 @@
               </:content>
             </Item>
           {{/if}}
-        </Grid>
+        </Card.Grid>
       </:card>
     </DataCard>
 
@@ -163,9 +163,9 @@
         <:title>
           Gerelateerde organisaties
         </:title>
-        <:card as |Grid|>
+        <:card as |Card|>
           {{#if @model.administrativeUnit.isSubOrganizationOf.name}}
-            <Grid as |Item|>
+            <Card.Grid as |Item|>
               <Item>
                 <:label>Centraal bestuur</:label>
                 <:content>
@@ -177,11 +177,11 @@
                   </AuLink>
                 </:content>
               </Item>
-            </Grid>
+            </Card.Grid>
           {{/if}}
           {{#if @model.administrativeUnit.subOrganizations}}
             {{#each @model.administrativeUnit.subOrganizations as |worship|}}
-              <Grid as |Item|>
+              <Card.Grid as |Item|>
                 <Item>
                   <:label>Bestuur van de eredienst</:label>
                   <:content>
@@ -193,11 +193,11 @@
                     </AuLink>
                   </:content>
                 </Item>
-              </Grid>
+              </Card.Grid>
             {{/each}}
           {{/if}}
           {{#if @model.administrativeUnit.isAssociatedWith.name}}
-            <Grid as |Item|>
+            <Card.Grid as |Item|>
               <Item>
                 <:label>Representatief orgaan</:label>
                 <:content>
@@ -209,7 +209,7 @@
                   </AuLink>
                 </:content>
               </Item>
-            </Grid>
+            </Card.Grid>
           {{/if}}
         </:card>
       </DataCard>

--- a/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/index.hbs
@@ -25,8 +25,8 @@
 
     <DataCard>
       <:title>Bestuursorgaan</:title>
-      <:card as |Grid|>
-        <Grid as |Item|>
+      <:card as |Card|>
+        <Card.Grid as |Item|>
           <Item>
             <:label>Type</:label>
             <:content
@@ -47,7 +47,7 @@
             <:label>Einddatum</:label>
             <:content>{{date-format @model.govBodyTimeSpec.endDate}}</:content>
           </Item>
-        </Grid>
+        </Card.Grid>
       </:card>
     </DataCard>
 

--- a/app/templates/administrative-units/administrative-unit/ministers/new.hbs
+++ b/app/templates/administrative-units/administrative-unit/ministers/new.hbs
@@ -20,8 +20,8 @@
     >
       <EditCard>
         <:title>Persoon zoeken</:title>
-        <:card as |Grid|>
-          <Grid as |Item|>
+        <:card as |Card|>
+          <Card.Grid as |Item|>
             <Item @labelFor="person-given-name">
               <:label>Voornaam</:label>
               <:content>
@@ -42,7 +42,7 @@
                 />
               </:content>
             </Item>
-          </Grid>
+          </Card.Grid>
           <div class="au-u-padding-tiny au-u-text-right">
             <AuButton
               @disabled={{not this.canSearch}}
@@ -120,8 +120,8 @@
     >
       <DataCard>
         <:title>Persoonlijke gegevens</:title>
-        <:card as |Grid|>
-          <Grid as |Item|>
+        <:card as |Card|>
+          <Card.Grid as |Item|>
             <Item>
               <:label>
                 Voornaam
@@ -138,14 +138,14 @@
                 {{this.targetPerson.familyName}}
               </:content>
             </Item>
-          </Grid>
+          </Card.Grid>
         </:card>
       </DataCard>
 
       <EditCard>
         <:title>Positie</:title>
-        <:card as |Grid|>
-          <Grid as |Item|>
+        <:card as |Card|>
+          <Card.Grid as |Item|>
             <Item>
               <:label>Positie</:label>
               <:content>
@@ -155,14 +155,14 @@
                 />
               </:content>
             </Item>
-          </Grid>
+          </Card.Grid>
         </:card>
       </EditCard>
 
       <EditCard>
         <:title>Contactgegevens</:title>
-        <:card as |Grid|>
-          <Grid as |Item|>
+        <:card as |Card|>
+          <Card.Grid as |Item|>
             <Item @labelFor="address-street-name">
               <:label>Straat</:label>
               <:content>
@@ -235,10 +235,10 @@
                 />
               </:content>
             </Item>
-          </Grid>
+          </Card.Grid>
 
           {{! Force a new row }}
-          <Grid as |Item|>
+          <Card.Grid as |Item|>
             <Item @labelFor="address-municipality">
               <:label>Gemeente</:label>
               <:content>
@@ -248,10 +248,10 @@
                 />
               </:content>
             </Item>
-          </Grid>
+          </Card.Grid>
 
           {{! Force a new row }}
-          <Grid as |Item|>
+          <Card.Grid as |Item|>
             <Item @labelFor="address-province">
               <:label>Provincie</:label>
               <:content>
@@ -261,14 +261,14 @@
                 />
               </:content>
             </Item>
-          </Grid>
+          </Card.Grid>
         </:card>
       </EditCard>
 
       <EditCard>
         <:title>Aanstelling</:title>
-        <:card as |Grid|>
-          <Grid as |Item|>
+        <:card as |Card|>
+          <Card.Grid as |Item|>
             <Item @labelFor="start-date">
               <:label>Startdatum</:label>
               <:content>
@@ -306,14 +306,14 @@
                 />
               </:content>
             </Item>
-          </Grid>
+          </Card.Grid>
         </:card>
       </EditCard>
 
       <EditCard>
         <:title>Financiering</:title>
-        <:card as |Grid|>
-          <Grid as |Item|>
+        <:card as |Card|>
+          <Card.Grid as |Item|>
             <Item @alignTop={{true}}>
               <:label>FOD financiering</:label>
               <:content>
@@ -335,7 +335,7 @@
                 />
               </:content>
             </Item>
-          </Grid>
+          </Card.Grid>
         </:card>
       </EditCard>
 

--- a/app/templates/administrative-units/administrative-unit/sites/site/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/sites/site/edit.hbs
@@ -18,8 +18,8 @@
       <div class="au-o-flow au-o-flow--large">
         <EditCard>
           <:title>Kerngegevens</:title>
-          <:card as |Grid|>
-            <Grid as |Item|>
+          <:card as |Card|>
+            <Card.Grid as |Item|>
               <Item>
                 <:label>Vestigingstype</:label>
                 <:content>
@@ -53,14 +53,14 @@
                   />
                 </:content>
               </Item>
-            </Grid>
+            </Card.Grid>
           </:card>
         </EditCard>
 
         <EditCard>
           <:title>Contactgegevens</:title>
-          <:card as |Grid|>
-            <Grid as |Item|>
+          <:card as |Card|>
+            <Card.Grid as |Item|>
               <Item @labelFor="primary-site-address-street-name">
                 <:label>Straat</:label>
                 <:content>
@@ -143,7 +143,7 @@
                   />
                 </:content>
               </Item>
-            </Grid>
+            </Card.Grid>
           </:card>
         </EditCard>
 

--- a/app/templates/administrative-units/administrative-unit/sites/site/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/sites/site/index.hbs
@@ -26,8 +26,8 @@
 
     <DataCard>
       <:title>Kerngegevens</:title>
-      <:card as |Grid|>
-        <Grid as |Item|>
+      <:card as |Card|>
+        <Card.Grid as |Item|>
           <Item>
             <:label>Vestigingstype</:label>
             <:content>{{@model.site.siteType.label}}</:content>
@@ -41,14 +41,14 @@
               }}
             </:content>
           </Item>
-        </Grid>
+        </Card.Grid>
       </:card>
     </DataCard>
 
     <DataCard>
       <:title>Contactgegevens</:title>
-      <:card as |Grid|>
-        <Grid as |Item|>
+      <:card as |Card|>
+        <Card.Grid as |Item|>
           <Item>
             <:label>Adres</:label>
             <:content>{{@model.site.address.fullAddress}}</:content>
@@ -70,7 +70,7 @@
               <:content>{{@model.site.contacts.firstObject.website}}</:content>
             </Item>
           {{/if}}
-        </Grid>
+        </Card.Grid>
       </:card>
     </DataCard>
   </div>

--- a/app/templates/people/person/personal-information/edit.hbs
+++ b/app/templates/people/person/personal-information/edit.hbs
@@ -16,8 +16,8 @@
       <div class="au-o-flow au-o-flow--large">
         <EditCard>
           <:title>Persoonlijke gegevens</:title>
-          <:card as |Grid|>
-            <Grid as |Item|>
+          <:card as |Card|>
+            <Card.Grid as |Item|>
               <Item @labelFor="person-given-name">
                 <:label>Voornaam</:label>
                 <:content>
@@ -45,8 +45,8 @@
                   />
                 </:content>
               </Item>
-            </Grid>
-            <Grid as |Item|>
+            </Card.Grid>
+            <Card.Grid as |Item|>
               <Item @labelFor="person-used-name">
                 <:label>Roepnaam</:label>
                 <:content>
@@ -57,7 +57,7 @@
                   />
                 </:content>
               </Item>
-            </Grid>
+            </Card.Grid>
           </:card>
         </EditCard>
 

--- a/app/templates/people/person/personal-information/index.hbs
+++ b/app/templates/people/person/personal-information/index.hbs
@@ -26,27 +26,27 @@
 
     <DataCard>
       <:title>Persoonlijke gegevens</:title>
-      <:card as |Grid|>
-        <Grid as |Item|>
+      <:card as |Card|>
+        <Card.Grid as |Item|>
           <Item>
             <:label>Voornaam</:label>
             <:content>{{@model.person.givenName}}</:content>
           </Item>
-        </Grid>
-        <Grid as |Item|>
+        </Card.Grid>
+        <Card.Grid as |Item|>
           <Item>
             <:label>Achternaam</:label>
             <:content>{{@model.person.familyName}}</:content>
           </Item>
-        </Grid>
-        <Grid as |Item|>
+        </Card.Grid>
+        <Card.Grid as |Item|>
           {{#if @model.person.firstNameUsed}}
             <Item>
               <:label>Roepnaam</:label>
               <:content>{{@model.person.firstNameUsed}}</:content>
             </Item>
           {{/if}}
-        </Grid>
+        </Card.Grid>
       </:card>
     </DataCard>
 
@@ -54,8 +54,8 @@
       <:title>Contactgegevens:
         {{@model.person.mandatories.firstObject.mandate.governingBody.isTimeSpecializationOf.administrativeUnit.classification.label}}
       </:title>
-      <:card as |Grid|>
-        <Grid as |Item|>
+      <:card as |Card|>
+        <Card.Grid as |Item|>
           <Item>
             <:label>Organisatie</:label>
             <:content>
@@ -67,8 +67,8 @@
               </AuLink>
             </:content>
           </Item>
-        </Grid>
-        <Grid as |Item|>
+        </Card.Grid>
+        <Card.Grid as |Item|>
           {{#if
             @model.person.mandatories.firstObject.contacts.firstObject.email
           }}
@@ -103,7 +103,7 @@
             <:label>GSM nummer</:label>
             <:content></:content>
           </Item> }}
-        </Grid>
+        </Card.Grid>
       </:card>
     </DataCard>
   </div>

--- a/app/templates/people/person/positions/position/index.hbs
+++ b/app/templates/people/person/positions/position/index.hbs
@@ -36,8 +36,8 @@
 
     <DataCard>
       <:title>Positie</:title>
-      <:card as |Grid|>
-        <Grid as |Item|>
+      <:card as |Card|>
+        <Card.Grid as |Item|>
           <Item>
             {{! TODO: Make it variable to also have Bedienaar}}
             <:label>Type</:label>
@@ -63,15 +63,15 @@
             <:label>Bestuursfunctie</:label>
             <:content>{{@model.mandatory.mandate.roleBoard.label}}</:content>
           </Item>
-        </Grid>
+        </Card.Grid>
       </:card>
     </DataCard>
 
     {{#if @model.mandatory.contacts}}
       <DataCard>
         <:title>Primaire contactgegevens</:title>
-        <:card as |Grid|>
-          <Grid as |Item|>
+        <:card as |Card|>
+          <Card.Grid as |Item|>
             {{#if @model.mandatory.contacts.firstObject.email}}
               <Item>
                 <:label>Email</:label>
@@ -99,15 +99,15 @@
                 </:content>
               </Item>
             {{/if}}
-          </Grid>
+          </Card.Grid>
         </:card>
       </DataCard>
     {{/if}}
 
     <DataCard>
       <:title>Aanstelling</:title>
-      <:card as |Grid|>
-        <Grid as |Item|>
+      <:card as |Card|>
+        <Card.Grid as |Item|>
           <Item>
             <:label>Start mandaat</:label>
             <:content>{{date-format @model.mandatory.startDate}}</:content>
@@ -144,7 +144,7 @@
               <:content>{{@model.mandatory.reasonStopped}}</:content>
             </Item>
           {{/if}}
-        </Grid>
+        </Card.Grid>
       </:card>
     </DataCard>
   </div>


### PR DESCRIPTION
This adds a Columns option to the cards components:

```hbs
        <EditCard>
          <:title>Bestuurseenheid</:title>
          <:card as |Card|>
            <Card.Columns>
             <:left as |Item|>...</:left>
             <:right as |Item|>...</:right>
           </Card.Columns>
        </EditCard>
```

This is a breaking change since the previous version did not yield an object. I fixed this for all the existing code, but branches will need to be updated:

before:
```hbs
        <EditCard>
          <:title>Bestuurseenheid</:title>
          <:card as |Grid|>
            <Grid as |Item|>
             ...
           </Grid>
        </EditCard>
```

after:
```hbs
        <EditCard>
          <:title>Bestuurseenheid</:title>
          <:card as |Card|>
            <Card.Grid as |Item|>
            ...
           </Card.Grid>
        </EditCard>
```