### PR TITLE
Create a `<PageHeader>` component

### DIFF
--- a/app/components/page-header.hbs
+++ b/app/components/page-header.hbs
@@ -1,0 +1,23 @@
+<header ...attributes>
+  {{#if (has-block "action")}}
+    <AuToolbar>
+      <AuToolbarGroup>
+        <AuHeading>
+          {{yield to="title"}}
+        </AuHeading>
+      </AuToolbarGroup>
+      <AuToolbarGroup>
+        {{yield to="action"}}
+      </AuToolbarGroup>
+    </AuToolbar>
+  {{else}}
+    <AuHeading>
+      {{yield to="title"}}
+    </AuHeading>
+  {{/if}}
+  {{#if (has-block "subtitle")}}
+    <AuHeading @level="2" @skin="3" class="au-u-margin-top-tiny au-u-margin-bottom-large">
+      {{yield to="subtitle"}}
+    </AuHeading>
+  {{/if}}
+</header>


### PR DESCRIPTION
This can be used as a replacement for the copy pasted header structures.

Usage:
```hbs
    <PageHeader>
      <:title>Kerngegevens</:title>
      <:subtitle>{{! optional}} {{@model.administrativeUnit.name}}</:subtitle>
      <:action>
        {{! optional}}
        <AuLink
          @route="administrative-units.administrative-unit.core-data.edit"
          @skin="button-secondary"
          @icon="pencil"
          @iconAlignment="left"
        >
          Bewerk
        </AuLink>
      </:action>
    <PageHeader>
```