### PR TITLE
Add explicit inverse relationship names

### DIFF
--- a/app/models/administrative-unit.js
+++ b/app/models/administrative-unit.js
@@ -2,8 +2,23 @@ import { hasMany, belongsTo } from '@ember-data/model';
 import OrganizationModel from './organization';
 
 export default class AdministrativeUnitModel extends OrganizationModel {
-  @belongsTo('administrative-unit-classification-code') classification;
-  @belongsTo('location', { inverse: 'administrativeUnit' }) scope;
-  @hasMany('governing-body', { inverse: 'administrativeUnit' }) governingBodies;
-  @hasMany('local-involvement') involvedBoards;
+  @belongsTo('administrative-unit-classification-code', {
+    inverse: null,
+  })
+  classification;
+
+  @belongsTo('location', {
+    inverse: 'administrativeUnit',
+  })
+  scope;
+
+  @hasMany('governing-body', {
+    inverse: 'administrativeUnit',
+  })
+  governingBodies;
+
+  @hasMany('local-involvement', {
+    inverse: 'administrativeUnit',
+  })
+  involvedBoards;
 }

--- a/app/models/agent-in-position.js
+++ b/app/models/agent-in-position.js
@@ -3,7 +3,19 @@ import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 export default class AgentInPositionModel extends Model {
   @attr('date') agentStartDate;
   @attr('date') agentEndDate;
-  @belongsTo('post') position;
-  @belongsTo('person') person;
-  @hasMany('contact-point') contacts;
+
+  @belongsTo('post', {
+    inverse: 'agentsInPosition',
+  })
+  position;
+
+  @belongsTo('person', {
+    inverse: 'agentsInPosition',
+  })
+  person;
+
+  @hasMany('contact-point', {
+    inverse: null,
+  })
+  contacts;
 }

--- a/app/models/associated-legal-structure.js
+++ b/app/models/associated-legal-structure.js
@@ -2,7 +2,19 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class AssociatedLegalStructureModel extends Model {
   @attr name;
-  @belongsTo('identifier') registration;
-  @belongsTo('legal-form-type') legalType;
-  @belongsTo('address') address;
+
+  @belongsTo('identifier', {
+    inverse: null,
+  })
+  registration;
+
+  @belongsTo('legal-form-type', {
+    inverse: null,
+  })
+  legalType;
+
+  @belongsTo('address', {
+    inverse: null,
+  })
+  address;
 }

--- a/app/models/change-event.js
+++ b/app/models/change-event.js
@@ -3,5 +3,9 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 export default class ChangeEventModel extends Model {
   @attr('date') date;
   @attr description;
-  @belongsTo('change-event-type') type;
+
+  @belongsTo('change-event-type', {
+    inverse: null,
+  })
+  type;
 }

--- a/app/models/contact-point.js
+++ b/app/models/contact-point.js
@@ -5,5 +5,9 @@ export default class ContactPointModel extends Model {
   @attr telephone;
   @attr fax;
   @attr website;
-  @belongsTo('address') contactAddress;
+
+  @belongsTo('address', {
+    inverse: null,
+  })
+  contactAddress;
 }

--- a/app/models/governing-body.js
+++ b/app/models/governing-body.js
@@ -3,14 +3,31 @@ import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 export default class GoverningBodyModel extends Model {
   @attr('date') startDate;
   @attr('date') endDate;
-  @belongsTo('administrative-unit') administrativeUnit;
-  @belongsTo('governing-body-classification-code', { inverse: null })
+
+  @belongsTo('administrative-unit', {
+    inverse: 'governingBodies',
+  })
+  administrativeUnit;
+
+  @belongsTo('governing-body-classification-code', {
+    inverse: null,
+  })
   classification;
-  @belongsTo('governing-body', { inverse: 'hasTimeSpecializations' })
+
+  @belongsTo('governing-body', {
+    inverse: 'hasTimeSpecializations',
+  })
   isTimeSpecializationOf;
-  @hasMany('governing-body', { inverse: 'isTimeSpecializationOf' })
+
+  @hasMany('governing-body', {
+    inverse: 'isTimeSpecializationOf',
+  })
   hasTimeSpecializations;
-  @hasMany('mandate') mandates;
+
+  @hasMany('mandate', {
+    inverse: 'governingBody',
+  })
+  mandates;
 
   get period() {
     let period = '';

--- a/app/models/identifier.js
+++ b/app/models/identifier.js
@@ -2,5 +2,9 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class IdentifierModel extends Model {
   @attr idName;
-  @belongsTo('structured-identifier') structuredIdentifier;
+
+  @belongsTo('structured-identifier', {
+    inverse: null,
+  })
+  structuredIdentifier;
 }

--- a/app/models/local-involvement.js
+++ b/app/models/local-involvement.js
@@ -2,8 +2,19 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class PublicInvolvementModel extends Model {
   @attr percentage;
-  @belongsTo('involvement-type') involvementType;
-  @belongsTo('worship-service') worshipService;
-  @belongsTo('administrative-unit', { inverse: 'involvedBoards' })
+
+  @belongsTo('involvement-type', {
+    inverse: null,
+  })
+  involvementType;
+
+  @belongsTo('worship-service', {
+    inverse: 'involvements',
+  })
+  worshipService;
+
+  @belongsTo('administrative-unit', {
+    inverse: 'involvedBoards',
+  })
   administrativeUnit;
 }

--- a/app/models/location.js
+++ b/app/models/location.js
@@ -3,5 +3,9 @@ import Model, { attr, hasMany } from '@ember-data/model';
 export default class LocationModel extends Model {
   @attr label;
   @attr level;
-  @hasMany('administrative-unit', { inverse: 'scope' }) administrativeUnit;
+
+  @hasMany('administrative-unit', {
+    inverse: 'scope',
+  })
+  administrativeUnit;
 }

--- a/app/models/mandate.js
+++ b/app/models/mandate.js
@@ -2,7 +2,18 @@ import { hasMany, belongsTo } from '@ember-data/model';
 import PostModel from './post';
 
 export default class MandateModel extends PostModel {
-  @belongsTo('board-position') roleBoard;
-  @belongsTo('governing-body', { inverse: 'mandates' }) governingBody;
-  @hasMany('mandatory', { inverse: 'mandate' }) heldBy;
+  @belongsTo('board-position', {
+    inverse: null,
+  })
+  roleBoard;
+
+  @belongsTo('governing-body', {
+    inverse: 'mandates',
+  })
+  governingBody;
+
+  @hasMany('mandatory', {
+    inverse: 'mandate',
+  })
+  heldBy;
 }

--- a/app/models/mandatory.js
+++ b/app/models/mandatory.js
@@ -3,8 +3,24 @@ import AgentInPositionModel from './agent-in-position';
 export default class MandatoryModel extends AgentInPositionModel {
   @attr('date') startDate;
   @attr('date') endDate;
-  @belongsTo('mandatory-status-code') status;
-  @belongsTo('person') governingAlias;
-  @belongsTo('mandate') mandate;
-  @hasMany('contact-point') contacts;
+
+  @belongsTo('mandatory-status-code', {
+    inverse: null,
+  })
+  status;
+
+  @belongsTo('person', {
+    inverse: 'mandatories',
+  })
+  governingAlias;
+
+  @belongsTo('mandate', {
+    inverse: 'heldBy',
+  })
+  mandate;
+
+  @hasMany('contact-point', {
+    inverse: null,
+  })
+  contacts;
 }

--- a/app/models/minister-condition.js
+++ b/app/models/minister-condition.js
@@ -2,6 +2,14 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class MinisterConditionModel extends Model {
   @attr satisfied;
-  @belongsTo('minister-conditions-criterion') criterion;
-  @belongsTo('document-type-criterion') documentTypeCriterion;
+
+  @belongsTo('minister-conditions-criterion', {
+    inverse: null,
+  })
+  criterion;
+
+  @belongsTo('document-type-criterion', {
+    inverse: null,
+  })
+  documentTypeCriterion;
 }

--- a/app/models/minister-position.js
+++ b/app/models/minister-position.js
@@ -2,8 +2,18 @@ import { belongsTo } from '@ember-data/model';
 import PostModel from './post';
 
 export default class MinisterPositionModel extends PostModel {
-  @belongsTo('minister-position-function') function;
-  @belongsTo('worship-service', { inverse: 'ministerPositions' })
+  @belongsTo('minister-position-function', {
+    inverse: null,
+  })
+  function;
+
+  @belongsTo('worship-service', {
+    inverse: 'ministerPositions',
+  })
   worshipService;
-  @belongsTo('representative-body') representativeBody;
+
+  @belongsTo('representative-body', {
+    inverse: 'ministerPositions',
+  })
+  representativeBody;
 }

--- a/app/models/minister.js
+++ b/app/models/minister.js
@@ -2,7 +2,18 @@ import { hasMany, belongsTo } from '@ember-data/model';
 import AgentInPositionModel from './agent-in-position';
 
 export default class MinisterModel extends AgentInPositionModel {
-  @belongsTo('minister-position') ministerPosition;
-  @belongsTo('financing-code') financing;
-  @hasMany('minister-condition') conditions;
+  @belongsTo('minister-position', {
+    inverse: null,
+  })
+  ministerPosition;
+
+  @belongsTo('financing-code', {
+    inverse: null,
+  })
+  financing;
+
+  @hasMany('minister-condition', {
+    inverse: null,
+  })
+  conditions;
 }

--- a/app/models/organization.js
+++ b/app/models/organization.js
@@ -3,18 +3,59 @@ import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 export default class OrganizationModel extends Model {
   @attr name;
   @attr alternativeName;
-  @belongsTo('site') primarySite;
-  @belongsTo('organization-status-code') organizationStatus;
-  @hasMany('identifier', { inverse: null }) identifiers;
-  @hasMany('site', { inverse: null }) sites;
-  @hasMany('change-event', { inverse: null }) changedBy;
-  @hasMany('change-event', { inverse: null }) resultedFrom;
-  @hasMany('post', { inverse: null }) positions;
-  @hasMany('organization', { inverse: 'isSubOrganizationOf' }) subOrganizations;
-  @belongsTo('organization', { inverse: 'subOrganizations' })
+
+  @belongsTo('site', {
+    inverse: null,
+  })
+  primarySite;
+
+  @belongsTo('organization-status-code', {
+    inverse: null,
+  })
+  organizationStatus;
+
+  @hasMany('identifier', {
+    inverse: null,
+  })
+  identifiers;
+
+  @hasMany('site', {
+    inverse: null,
+  })
+  sites;
+
+  @hasMany('change-event', {
+    inverse: null,
+  })
+  changedBy;
+
+  @hasMany('change-event', {
+    inverse: null,
+  })
+  resultedFrom;
+
+  @hasMany('post', {
+    inverse: null,
+  })
+  positions;
+
+  @hasMany('organization', {
+    inverse: 'isSubOrganizationOf',
+  })
+  subOrganizations;
+
+  @belongsTo('organization', {
+    inverse: 'subOrganizations',
+  })
   isSubOrganizationOf;
-  @hasMany('organization', { inverse: 'isAssociatedWith' })
+
+  @hasMany('organization', {
+    inverse: 'isAssociatedWith',
+  })
   associatedOrganizations;
-  @belongsTo('organization', { inverse: 'associatedOrganizations' })
+
+  @belongsTo('organization', {
+    inverse: 'associatedOrganizations',
+  })
   isAssociatedWith;
 }

--- a/app/models/person.js
+++ b/app/models/person.js
@@ -4,9 +4,29 @@ export default class PersonModel extends Model {
   @attr givenName;
   @attr familyName;
   @attr firstNameUsed;
-  @hasMany('mandatory', { inverse: 'governingAlias' }) mandatories;
-  @hasMany('agent-in-position', { inverse: 'person' }) agentsInPosition;
-  @hasMany('nationality') nationalities;
-  @belongsTo('date-of-birth') dateOfBirth;
-  @belongsTo('gender-code') gender;
+
+  @hasMany('mandatory', {
+    inverse: 'governingAlias',
+  })
+  mandatories;
+
+  @hasMany('agent-in-position', {
+    inverse: 'person',
+  })
+  agentsInPosition;
+
+  @hasMany('nationality', {
+    inverse: null,
+  })
+  nationalities;
+
+  @belongsTo('date-of-birth', {
+    inverse: null,
+  })
+  dateOfBirth;
+
+  @belongsTo('gender-code', {
+    inverse: null,
+  })
+  gender;
 }

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -1,7 +1,18 @@
 import Model, { belongsTo, hasMany } from '@ember-data/model';
 
 export default class PostModel extends Model {
-  @belongsTo('role') generalRole;
-  @belongsTo('organization') organization;
-  @hasMany('agent-in-position', { inverse: 'position' }) agentsInPosition;
+  @belongsTo('role', {
+    inverse: null,
+  })
+  generalRole;
+
+  @belongsTo('organization', {
+    inverse: null,
+  })
+  organization;
+
+  @hasMany('agent-in-position', {
+    inverse: 'position',
+  })
+  agentsInPosition;
 }

--- a/app/models/representative-body.js
+++ b/app/models/representative-body.js
@@ -2,7 +2,13 @@ import { belongsTo, hasMany } from '@ember-data/model';
 import OrganizationModel from './organization';
 
 export default class RepresentativeBodyModel extends OrganizationModel {
-  @belongsTo('recognized-worship-type') recognizedWorshipType;
-  @hasMany('minister-positions', { inverse: 'representativeBody' })
+  @belongsTo('recognized-worship-type', {
+    inverse: null,
+  })
+  recognizedWorshipType;
+
+  @hasMany('minister-positions', {
+    inverse: 'representativeBody',
+  })
   ministerPositions;
 }

--- a/app/models/site.js
+++ b/app/models/site.js
@@ -1,7 +1,18 @@
 import Model, { hasMany, belongsTo } from '@ember-data/model';
 
 export default class SiteModel extends Model {
-  @belongsTo('address') address;
-  @hasMany('contact-point', { inverse: null }) contacts;
-  @belongsTo('site-type') siteType;
+  @belongsTo('address', {
+    inverse: null,
+  })
+  address;
+
+  @hasMany('contact-point', {
+    inverse: null,
+  })
+  contacts;
+
+  @belongsTo('site-type', {
+    inverse: null,
+  })
+  siteType;
 }

--- a/app/models/worship-administrative-unit.js
+++ b/app/models/worship-administrative-unit.js
@@ -2,5 +2,8 @@ import { belongsTo } from '@ember-data/model';
 import AdministrativeUnitModel from './administrative-unit';
 
 export default class WorshipAdministrativeUnitModel extends AdministrativeUnitModel {
-  @belongsTo('recognized-worship-type') recognizedWorshipType;
+  @belongsTo('recognized-worship-type', {
+    inverse: null,
+  })
+  recognizedWorshipType;
 }

--- a/app/models/worship-mandatory.js
+++ b/app/models/worship-mandatory.js
@@ -4,5 +4,9 @@ import MandatoryModel from './mandatory';
 export default class WorshipMandatoryModel extends MandatoryModel {
   @attr('date') expectedEndDate;
   @attr reasonStopped;
-  @belongsTo('half-election') typeHalf;
+
+  @belongsTo('half-election', {
+    inverse: null,
+  })
+  typeHalf;
 }

--- a/app/models/worship-service.js
+++ b/app/models/worship-service.js
@@ -4,8 +4,16 @@ import WorshipAdministrativeUnitModel from './worship-administrative-unit';
 export default class WorshipServiceModel extends WorshipAdministrativeUnitModel {
   @attr denomination;
   @attr crossBorder;
-  @hasMany('minister-position') ministerPositions;
-  @hasMany('local-involvements', { inverse: 'worshipService' }) involvements;
+
+  @hasMany('minister-position', {
+    inverse: 'worshipService',
+  })
+  ministerPositions;
+
+  @hasMany('local-involvements', {
+    inverse: 'worshipService',
+  })
+  involvements;
 
   get crossBorderNominal() {
     if (this.crossBorder) {


### PR DESCRIPTION
I noticed a missing inverse related error message when clicking through the administrative units search pages so I decided to add it to all the relationships. Most of the changes are just formatting though.

More info: https://github.com/emberjs/rfcs/pull/739

Error message:
```
Uncaught Error: Assertion Failed: You defined the 'involvedBoards' relationship on model:worship-service, but you defined the inverse relationships of type model:local-involvement multiple times. Look at https://guides.emberjs.com/current/models/relationships/#toc_explicit-inverses for how to explicitly specify inverses
```