### PR TITLE
Limit the width of the login page content

### DIFF
--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -10,98 +10,102 @@
   />
 </AuContentHeader>
 
-<section class="au-o-box au-o-box--large">
-  <div class="au-o-grid au-o-grid--small">
-    <div class="au-o-grid__item au-u-3-4@small au-u-1-2@medium">
-      <AuContent @skin="large">
-        <h1>Organisatieportaal</h1>
-        <p class="au-c-heading au-c-heading--4">Een webapplicatie die helpt met
-          het visualiseren en bewerken van data over besturen van een eredienst
-          en personen.</p>
-        <p>Lukt het aanmelden niet? Neem contact op met uw interne beheerder.
-          Indien er zich een probleem voordoet, contacteer
-          <a
-            class="au-c-link"
-            href="https://overheid.vlaanderen.be/ict/ict-diensten/gebruikersbeheer"
-          >gebruikersbeheer Vlaanderen</a>.</p>
-        <p>Het aanmelden gebeurt in een pop-up; zorg dat de instellingen van uw
-          browser correct staan indien deze niet verschijnt.</p>
-      </AuContent>
-    </div>
-    <div
-      class="au-o-grid__item au-u-1-4@small au-u-1-2@medium au-u-text-right@medium"
-    >
-      <AuButton @icon="login" @iconAlignment="left">
-        Aanmelden
-      </AuButton>
+<section class="au-o-region-large">
+  <div class="au-o-layout">
+    <div class="au-o-grid au-o-grid--small">
+      <div class="au-o-grid__item au-u-3-4@small au-u-1-2@medium">
+        <AuContent @skin="large">
+          <h1>Organisatieportaal</h1>
+          <p class="au-c-heading au-c-heading--4">Een webapplicatie die helpt met
+            het visualiseren en bewerken van data over besturen van een eredienst
+            en personen.</p>
+          <p>Lukt het aanmelden niet? Neem contact op met uw interne beheerder.
+            Indien er zich een probleem voordoet, contacteer
+            <a
+              class="au-c-link"
+              href="https://overheid.vlaanderen.be/ict/ict-diensten/gebruikersbeheer"
+            >gebruikersbeheer Vlaanderen</a>.</p>
+          <p>Het aanmelden gebeurt in een pop-up; zorg dat de instellingen van uw
+            browser correct staan indien deze niet verschijnt.</p>
+        </AuContent>
+      </div>
+      <div
+        class="au-o-grid__item au-u-1-4@small au-u-1-2@medium au-u-text-right@medium"
+      >
+        <AuButton @icon="login" @iconAlignment="left">
+          Aanmelden
+        </AuButton>
+      </div>
     </div>
   </div>
 </section>
 
-<section class="au-o-box au-o-box--large au-u-background-gray-200">
-  <AuHeading @level="2" @skin="3" class="au-u-margin-bottom">
-    De functionaliteiten van het organisatieportaal
-  </AuHeading>
-  <div class="au-o-grid au-o-grid--small">
-    <div class="au-o-grid__item au-u-1-2@small">
-      <AuCard @flex="true" as |c|>
-        <c.header @badgeSkin="brand" @badgeIcon="sitemap">
-          <AuHeading @level="3" @skin="4">
-            Bestuurseenheden
-          </AuHeading>
-        </c.header>
-        <c.content>
-          <p>Bekijk en bewerk</p>
-          <ul>
-            <li>Kerninformatie over besturen</li>
-            <li>Bestuursorganen</li>
-            <li>Documenten en dossiers</li>
-          </ul>
-        </c.content>
-        <c.footer>
-          <p>
-            <a
-              class="au-c-link au-c-link--secondary"
-              href=""
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <AuIcon @icon="manual" @alignment="left" />
-              Handleiding
-            </a>
-          </p>
-        </c.footer>
-      </AuCard>
-    </div>
-    <div class="au-o-grid__item au-u-1-2@small">
-      <AuCard @flex="true" as |c|>
-        <c.header @badgeSkin="brand" @badgeIcon="users">
-          <AuHeading @level="3" @skin="4">
-            Personen
-          </AuHeading>
-        </c.header>
-        <c.content>
-          <p>Bekijk en bewerk</p>
-          <ul>
-            <li>Kerngegevens over personen</li>
-            <li>Contactgegevens</li>
-            <li>Posities</li>
-          </ul>
-        </c.content>
-        <c.footer>
-          <p>
-            <a
-              class="au-c-link au-c-link--secondary"
-              href=""
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <AuIcon @icon="manual" @alignment="left" />
-              Handleiding
-            </a>
-          </p>
-        </c.footer>
-      </AuCard>
+<section class="au-o-region-large au-u-background-gray-200">
+  <div class="au-o-layout">
+    <AuHeading @level="2" @skin="3" class="au-u-margin-bottom">
+      De functionaliteiten van het organisatieportaal
+    </AuHeading>
+    <div class="au-o-grid au-o-grid--small">
+      <div class="au-o-grid__item au-u-1-2@small">
+        <AuCard @flex="true" as |c|>
+          <c.header @badgeSkin="brand" @badgeIcon="sitemap">
+            <AuHeading @level="3" @skin="4">
+              Bestuurseenheden
+            </AuHeading>
+          </c.header>
+          <c.content>
+            <p>Bekijk en bewerk</p>
+            <ul>
+              <li>Kerninformatie over besturen</li>
+              <li>Bestuursorganen</li>
+              <li>Documenten en dossiers</li>
+            </ul>
+          </c.content>
+          <c.footer>
+            <p>
+              <a
+                class="au-c-link au-c-link--secondary"
+                href=""
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <AuIcon @icon="manual" @alignment="left" />
+                Handleiding
+              </a>
+            </p>
+          </c.footer>
+        </AuCard>
+      </div>
+      <div class="au-o-grid__item au-u-1-2@small">
+        <AuCard @flex="true" as |c|>
+          <c.header @badgeSkin="brand" @badgeIcon="users">
+            <AuHeading @level="3" @skin="4">
+              Personen
+            </AuHeading>
+          </c.header>
+          <c.content>
+            <p>Bekijk en bewerk</p>
+            <ul>
+              <li>Kerngegevens over personen</li>
+              <li>Contactgegevens</li>
+              <li>Posities</li>
+            </ul>
+          </c.content>
+          <c.footer>
+            <p>
+              <a
+                class="au-c-link au-c-link--secondary"
+                href=""
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <AuIcon @icon="manual" @alignment="left" />
+                Handleiding
+              </a>
+            </p>
+          </c.footer>
+        </AuCard>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
This makes it consistent with the other LBLOD apps and it looks way better on large screens.

Before:
![Screenshot 2021-08-02 at 16-54-49 Organisatieportaal](https://user-images.githubusercontent.com/3533236/127881483-4bb9dc0d-6651-431b-b439-9f75385b03ae.png)

After:
![Screenshot 2021-08-02 at 16-54-29 Organisatieportaal](https://user-images.githubusercontent.com/3533236/127881504-68ac8163-c87b-4b39-a7d8-ca865e5985fa.png)
