### PR TITLE
Disable the pagination in the PersonSearch component

### DIFF
--- a/app/components/person-search.hbs
+++ b/app/components/person-search.hbs
@@ -45,7 +45,7 @@
 </form>
 
 {{#if this.searchPeopleTask.last}}
-  <div class="au-u-margin-top-large">
+  <div class="person-search-results au-u-margin-top-large">
     <AuDataTable
       @content={{this.searchPeopleTask.lastSuccessful.value}}
       @isLoading={{and

--- a/app/components/person-search.js
+++ b/app/components/person-search.js
@@ -29,6 +29,11 @@ export default class PersonSearchComponent extends Component {
         query['filter[family-name]'] = this.searchParams.familyName;
       }
 
+      // TODO: implement pagination once it's possible without 2-way-binding
+      // More information: https://github.com/mu-semtech/ember-data-table/issues/27
+      // We temporarily increase the number of results to increase the chances that everything fits on one page
+      query['page[size]'] = 100;
+
       return yield this.store.query('person', query);
     }
   }

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -17,3 +17,11 @@ table.dataTable tbody th {
 .CodeMirror {
     max-height: 500px  !important;
 }
+
+.person-search-results {
+  // Hide the pagination until we can make it work without 2-way-binding
+  // https://github.com/mu-semtech/ember-data-table/issues/27
+  .au-c-data-table__actions--bottom {
+    display: none;
+  }
+}


### PR DESCRIPTION
The DataTable component doesn't support updating the page counter without 2-way-binding, which is a problem when it is not linked to a query parameter. Instead of using a bad workaround, it's better to disable pagination for now. Users will most likely search for a very specific person by typing their full name. This usually yields few enough results that pagination isn't strictly needed.

More information: https://github.com/mu-semtech/ember-data-table/issues/27