### PR TITLE
Don't update the browser history when changing filters

### DIFF
--- a/app/routes/administrative-units/index.js
+++ b/app/routes/administrative-units/index.js
@@ -19,6 +19,12 @@ export default class AdministrativeUnitsIndexRoute extends Route {
   queryParams = {
     page: { refreshModel: true },
     sort: { refreshModel: true },
+    name: { replace: true },
+    municipality: { replace: true },
+    province: { replace: true },
+    classification: { replace: true },
+    recognizedWorshipType: { replace: true },
+    organizationStatus: { replace: true },
   };
 
   async model(params) {

--- a/app/routes/people/index.js
+++ b/app/routes/people/index.js
@@ -8,6 +8,9 @@ export default class PeopleIndexRoute extends Route {
   queryParams = {
     page: { refreshModel: true },
     sort: { refreshModel: true },
+    givenName: { replace: true },
+    familyName: { replace: true },
+    organization: { replace: true },
   };
 
   model(params) {


### PR DESCRIPTION
Changing query params adds a lot of history entries by default so pressing back doesn't work as expected.