### PR TITLE
Temporarily hide links to unused pages

### DIFF
--- a/app/templates/administrative-units/administrative-unit.hbs
+++ b/app/templates/administrative-units/administrative-unit.hbs
@@ -29,11 +29,12 @@
               Betrokken lokale besturen
             </AuNavigationLink>
           </li>
+          {{!--           Link temporarily hidden until page is completed
           <li class="au-c-list-navigation__item">
             <AuNavigationLink>
               Verbonden Juridische structuren
             </AuNavigationLink>
-          </li>
+          </li> --}}
         {{/if}}
         <li class="au-c-list-navigation__item">
           <AuNavigationLink
@@ -51,6 +52,7 @@
             </AuNavigationLink>
           </li>
         {{/if}}
+        {{!--         Links temporarily hidden until page is completed
         {{#if (not-eq @model.constructor.modelName "central-worship-service")}}
           <li class="au-c-list-navigation__item">
             <AuNavigationLink>
@@ -67,7 +69,7 @@
           <AuNavigationLink>
             Dossiers
           </AuNavigationLink>
-        </li>
+        </li> --}}
       </ul>
     </div>
   </:sidebar>


### PR DESCRIPTION
To make sure we don't have to create new pages explaining why these pages do not exist just yet. We can show them again once the pages have been implemented – perhaps add a "new" label or a nice onboarding experience to the new feature.