### PR TITLE
Correct typos for field labels

### DIFF
--- a/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/mandatory/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/mandatory/edit.hbs
@@ -141,7 +141,7 @@
               </:left>
               <:right as |Item|>
                 <Item @labelFor="contact-email">
-                  <:label>Email</:label>
+                  <:label>E-mail</:label>
                   <:content>
                     <AuInput
                       @width="block"
@@ -151,7 +151,7 @@
                   </:content>
                 </Item>
                 <Item @labelFor="contact-telephone">
-                  <:label>Vaste telefoonnummer</:label>
+                  <:label>Vast telefoonnummer</:label>
                   <:content>
                     <AuInput
                       @width="block"

--- a/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/mandatory/new.hbs
+++ b/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/mandatory/new.hbs
@@ -109,7 +109,7 @@
             </:left>
             <:right as |Item|>
               <Item @labelFor="contact-email">
-                <:label>E-mailadres</:label>
+                <:label>E-mail</:label>
                 <:content>
                   <AuInput
                     @value={{@model.contact.email}}

--- a/app/templates/administrative-units/administrative-unit/ministers/new.hbs
+++ b/app/templates/administrative-units/administrative-unit/ministers/new.hbs
@@ -128,7 +128,7 @@
             </:left>
             <:right as |Item|>
               <Item @labelFor="contact-email">
-                <:label>E-mailadres</:label>
+                <:label>E-mail</:label>
                 <:content>
                   <AuInput
                     @value={{this.model.contact.email}}

--- a/app/templates/people/person/personal-information/index.hbs
+++ b/app/templates/people/person/personal-information/index.hbs
@@ -67,7 +67,7 @@
             @model.person.mandatories.firstObject.contacts.firstObject.email
           }}
             <Item>
-              <:label>Email</:label>
+              <:label>E-mail</:label>
               <:content>
                 {{@model.person.mandatories.firstObject.contacts.firstObject.email}}
               </:content>

--- a/app/templates/people/person/positions/mandatory/index.hbs
+++ b/app/templates/people/person/positions/mandatory/index.hbs
@@ -69,7 +69,7 @@
           <Card.Grid as |Item|>
             {{#if @model.mandatory.contacts.firstObject.email}}
               <Item>
-                <:label>Email</:label>
+                <:label>E-mail</:label>
                 <:content>
                   {{@model.mandatory.contacts.firstObject.email}}
                 </:content>
@@ -77,7 +77,7 @@
             {{/if}}
             {{#if @model.mandatory.contacts.firstObject.telephone}}
               <Item>
-                <:label>Vaste telefoonnummer</:label>
+                <:label>Vast telefoonnummer</:label>
                 <:content>
                   {{@model.mandatory.contacts.firstObject.telephone}}
                 </:content>

--- a/app/templates/people/person/positions/minister/index.hbs
+++ b/app/templates/people/person/positions/minister/index.hbs
@@ -70,7 +70,7 @@
             <:left as |Item|>
               {{#if @model.minister.contacts.firstObject.email}}
                 <Item>
-                  <:label>Email</:label>
+                  <:label>E-mail</:label>
                   <:content>
                     {{@model.minister.contacts.firstObject.email}}
                   </:content>
@@ -90,7 +90,7 @@
             <:right as |Item|>
               {{#if @model.minister.contacts.firstObject.telephone}}
                 <Item>
-                  <:label>Vaste telefoonnummer</:label>
+                  <:label>Vast telefoonnummer</:label>
                   <:content>
                     {{@model.minister.contacts.firstObject.telephone}}
                   </:content>


### PR DESCRIPTION
For "e-mail" and "vast telefoonnummer"