### PR TITLE
Show all sites on the sites overview page

### DIFF
--- a/app/controllers/administrative-units/administrative-unit/sites/index.js
+++ b/app/controllers/administrative-units/administrative-unit/sites/index.js
@@ -2,15 +2,16 @@ import Controller from '@ember/controller';
 
 export default class AdministrativeUnitsAdministrativeUnitSitesIndexController extends Controller {
   get sites() {
-    if (this.model.sites.length > 0) {
-      return this.model.sites;
-    }
+    let sites = [];
 
-    // use the primary site as a fallback
     if (this.model.primarySite) {
-      return [this.model.primarySite];
+      sites = [this.model.primarySite];
     }
 
-    return [];
+    if (this.model.sites.length > 0) {
+      sites = [...sites, ...this.model.sites.toArray()];
+    }
+
+    return sites;
   }
 }


### PR DESCRIPTION
This makes sure all sites are visible instead of only the primary or non-primary ones.
The original assumption was that the primary site would be part of the sites relationship, which isn't the case.