### PR TITLE
Local involvements edit page improvements

### DIFF
--- a/app/controllers/administrative-units/administrative-unit/local-involvements/edit.js
+++ b/app/controllers/administrative-units/administrative-unit/local-involvements/edit.js
@@ -67,9 +67,8 @@ export default class AdministrativeUnitsAdministrativeUnitLocalInvolvementsEditC
 
     let involvements = yield this.model.involvements;
 
-    for (let involvement of involvements.toArray()) {
-      yield involvement.save();
-    }
+    let savePromises = involvements.map((involvement) => involvement.save());
+    yield Promise.all(savePromises);
 
     this.router.transitionTo(
       'administrative-units.administrative-unit.local-involvements',

--- a/app/templates/administrative-units/administrative-unit/local-involvements/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/local-involvements/edit.hbs
@@ -5,7 +5,8 @@
     <:subtitle>{{@model.administrativeUnit.name}}</:subtitle>
     <:action>
       <AuButton
-        @disabled={{this.isFinancingTotalNotValid}}
+        @loading={{this.save.isRunning}}
+        @disabled={{or this.isFinancingTotalNotValid this.save.isRunning}}
         form="local-involvements-edit-creation"
         type="submit"
       >


### PR DESCRIPTION
- Disable the edit button while saving
- Show a loading state while saving
- run the save calls in pararel to speed it up