### PR TITLE
Some required fields updates

### DIFF
--- a/app/components/edit-card.hbs
+++ b/app/components/edit-card.hbs
@@ -14,6 +14,12 @@
         )
         to="card"
       }}
+
+      {{#if @containsRequiredFields}}
+        <AuHelpText @skin="secondary" class="au-u-margin-top">
+          * Verplicht veld
+        </AuHelpText>
+      {{/if}}
     </div>
   </div>
 </div>

--- a/app/components/edit-card/item.hbs
+++ b/app/components/edit-card/item.hbs
@@ -7,6 +7,9 @@
       <AuLabel
         class="{{@labelClass}}"
         for={{@labelFor}}
+        @required={{@required}}
+        @requiredLabel="*"
+        @inline={{true}}
       >
         {{yield to="label"}}
       </AuLabel>

--- a/app/controllers/administrative-units/administrative-unit/ministers/new.js
+++ b/app/controllers/administrative-units/administrative-unit/ministers/new.js
@@ -24,9 +24,17 @@ export default class AdministrativeUnitsAdministrativeUnitMinistersNewController
     return !this.targetPerson;
   }
 
+  get canSubmit() {
+    return Boolean(this.model.position.function.get('id'));
+  }
+
   @dropTask
   *createMinisterPositionTask(event) {
     event.preventDefault();
+
+    if (!this.canSubmit) {
+      return;
+    }
 
     let {
       administrativeUnit,

--- a/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/mandatory/new.hbs
+++ b/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/mandatory/new.hbs
@@ -148,13 +148,13 @@
         </:card>
       </EditCard>
 
-      <EditCard>
+      <EditCard @containsRequiredFields={{true}}>
         <:title>Mandaat</:title>
         <:card as |Card|>
           <Card.Columns>
             <:left as |Item|>
-              <Item @labelFor="board-position">
-                <:label>Bestuursfunctie*</:label>
+              <Item @labelFor="board-position" @required={{true}}>
+                <:label>Bestuursfunctie</:label>
                 <:content>
                   <MandateRoleSelect
                     @selected={{this.selectedRole}}
@@ -228,9 +228,6 @@
               </Item>
             </:right>
           </Card.Columns>
-          <AuHelpText @skin="secondary" class="au-u-margin-top">
-            * Verplicht veld
-          </AuHelpText>
         </:card>
       </EditCard>
 

--- a/app/templates/administrative-units/administrative-unit/ministers/new.hbs
+++ b/app/templates/administrative-units/administrative-unit/ministers/new.hbs
@@ -46,12 +46,12 @@
         </:card>
       </DataCard>
 
-      <EditCard>
+      <EditCard @containsRequiredFields={{true}}>
         <:title>Positie</:title>
         <:card as |Card|>
           <Card.Columns>
             <:left as |Item|>
-              <Item>
+              <Item @required={{true}}>
                 <:label>Positie</:label>
                 <:content>
                   <MinisterPositionFunctionSelect
@@ -255,6 +255,7 @@
           @icon="add"
           @iconAlignment="left"
           @loading={{this.createMinisterPositionTask.isRunning}}
+          @disabled={{or (not this.canSubmit) this.createMinisterPositionTask.isRunning}}
           type="submit"
         >
           Voeg toe


### PR DESCRIPTION
This pr:
 - prevents the users from creating a minister position before selecting a function role first
 - adds required field styling as shown here: https://appuniversum.github.io/ember-appuniversum/docs/patterns/au-card-edit
 - updates the previous implemented required field on the mandatory creation page

Note: This is temporary / quick validation fix. The real validation implementation will include error messages and other data validations.

