### PR TITLE
Add plausible analytics script as built for gelinkt-notuleren

### DIFF
--- a/app/initializers/analytics.js
+++ b/app/initializers/analytics.js
@@ -1,0 +1,19 @@
+import ENV from 'frontend-contact-hub/config/environment';
+export function initialize(/* application */) {
+  if (
+    ENV.APP.analytics.appDomain !== '{{ANALYTICS_APP_DOMAIN}}' &&
+    ENV.APP.analytics.plausibleScript !== '{{ANALYTICS_PLAUSIBLE_SCRIPT}}'
+  ) {
+    const head = document.querySelector('head');
+    const script = document.createElement('script');
+    script.setAttribute('src', ENV.APP.analytics.plausibleScript);
+    script.setAttribute('data-domain', ENV.APP.analytics.appDomain);
+    script.setAttribute('async', 'async');
+    script.setAttribute('defer', 'defer');
+    head.appendChild(script);
+  }
+}
+
+export default {
+  initialize,
+};

--- a/config/environment.js
+++ b/config/environment.js
@@ -17,6 +17,10 @@ module.exports = function (environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
+      analytics: {
+        appDomain: '{{ANALYTICS_APP_DOMAIN}}',
+        plausibleScript: '{{ANALYTICS_PLAUSIBLE_SCRIPT}}',
+      },
     },
 
     appName: 'Organisatieportaal',

--- a/tests/unit/initializers/analytics-test.js
+++ b/tests/unit/initializers/analytics-test.js
@@ -1,0 +1,32 @@
+import Application from '@ember/application';
+
+import { initialize } from 'frontend-contact-hub/initializers/analytics';
+import { module, test } from 'qunit';
+import Resolver from 'ember-resolver';
+import { run } from '@ember/runloop';
+
+module('Unit | Initializer | analytics', function (hooks) {
+  hooks.beforeEach(function () {
+    this.TestApplication = class TestApplication extends Application {};
+    this.TestApplication.initializer({
+      name: 'initializer under test',
+      initialize,
+    });
+
+    this.application = this.TestApplication.create({
+      autoboot: false,
+      Resolver,
+    });
+  });
+
+  hooks.afterEach(function () {
+    run(this.application, 'destroy');
+  });
+
+  // TODO: Replace this with your real tests.
+  test('it works', async function (assert) {
+    await this.application.boot();
+
+    assert.ok(true);
+  });
+});


### PR DESCRIPTION
This script allows the specification of two environment variables through the docker-compose.override.yml.  When these are set correctly, plausible will be injected and logging will commence.

- `EMBER_ANALYTICS_APP_DOMAIN`: The domain for which the app should be monitored.

  eg: example.abb.vlaanderen.be

- `EMBER_ANALYTICS_PLAUSIBLE_SCRIPT`: Full path to the plausible script on the server.