### PR TITLE
Deep linking support

### DIFF
--- a/app/redirect-handlers/administrative-unit.js
+++ b/app/redirect-handlers/administrative-unit.js
@@ -1,0 +1,10 @@
+import { inject as service } from '@ember/service';
+import RedirectHandler from './redirect-handler';
+
+export default class AdministrativeUnitRedirectHandler extends RedirectHandler {
+  @service router;
+
+  redirect(uuid) {
+    this.router.replaceWith('administrative-units.administrative-unit', uuid);
+  }
+}

--- a/app/redirect-handlers/person.js
+++ b/app/redirect-handlers/person.js
@@ -1,0 +1,10 @@
+import { inject as service } from '@ember/service';
+import RedirectHandler from './redirect-handler';
+
+export default class PersonRedirectHandler extends RedirectHandler {
+  @service router;
+
+  redirect(uuid) {
+    this.router.replaceWith('people.person', uuid);
+  }
+}

--- a/app/redirect-handlers/redirect-handler.js
+++ b/app/redirect-handlers/redirect-handler.js
@@ -1,0 +1,14 @@
+// Based on these RFC issues:
+// https://github.com/emberjs/rfcs/issues/590
+// https://github.com/emberjs/rfcs/issues/600#issuecomment-595155795
+export default class RedirectHandler {
+  constructor(injections) {
+    Object.assign(this, injections);
+  }
+
+  redirect() {}
+
+  static create(injections) {
+    return new this(injections);
+  }
+}

--- a/app/router.js
+++ b/app/router.js
@@ -96,4 +96,5 @@ Router.map(function () {
   this.route('route-not-found', {
     path: '/*wildcard',
   });
+  this.route('redirect');
 });

--- a/app/routes/redirect.js
+++ b/app/routes/redirect.js
@@ -1,0 +1,24 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class RedirectRoute extends Route {
+  @service deepLink;
+  @service router;
+  @service session;
+
+  async beforeModel(transition) {
+    if (this.session.requireAuthentication(transition, 'login')) {
+      let { resource: resourceUri } = transition.to.queryParams;
+
+      if (!resourceUri) {
+        return this.router.replaceWith('index');
+      }
+
+      try {
+        await this.deepLink.redirect(resourceUri);
+      } catch (error) {
+        return this.router.replaceWith('index');
+      }
+    }
+  }
+}

--- a/app/services/deep-link.js
+++ b/app/services/deep-link.js
@@ -1,0 +1,95 @@
+import { getOwner } from '@ember/application';
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+
+// TODO: find a better way to store / configure the handlers map
+const REDIRECT_HANDLER = {
+  'http://www.w3.org/ns/person#Person': 'person',
+  'http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst':
+    'administrative-unit',
+  'http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst':
+    'administrative-unit',
+};
+
+export default class DeepLinkService extends Service {
+  @service uriInfo;
+
+  REDIRECT_HANDLER = REDIRECT_HANDLER;
+
+  async redirect(resourceUri) {
+    let uriInfo = await this.uriInfo.getDirectLinks(resourceUri);
+    let rdfTypes = getRdfTypes(uriInfo);
+    let uuid = getUuid(uriInfo);
+
+    if (rdfTypes.length > 0 && uuid) {
+      this._handleRedirect(rdfTypes, uuid, resourceUri);
+    } else {
+      throw new ResourceNotFoundError(
+        `No data found for ${resourceUri}`,
+        resourceUri
+      );
+    }
+  }
+
+  async _handleRedirect(types, uuid, resourceUri) {
+    let redirectHandler;
+
+    for (let type of types) {
+      if (redirectHandler) break;
+
+      let handlerName = this.REDIRECT_HANDLER[type];
+
+      redirectHandler = getOwner(this).lookup(
+        `redirect-handler:${handlerName}`
+      );
+    }
+
+    if (redirectHandler) {
+      await redirectHandler.redirect(uuid, resourceUri);
+    } else {
+      throw new RedirectHandlerNotFoundError(
+        `No redirect handler registered for "${types.join('", "')}"`,
+        {
+          types,
+          uuid,
+          resourceUri,
+        }
+      );
+    }
+  }
+}
+
+function getRdfTypes(uriInfo) {
+  const RDF_TYPE_URL = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+  let triples = uriInfo.triples.filter(
+    ({ predicate }) => predicate === RDF_TYPE_URL
+  );
+
+  return triples.map((triple) => triple.object.value);
+}
+
+function getUuid(uriInfo) {
+  const MU_UUID_URL = 'http://mu.semte.ch/vocabularies/core/uuid';
+  let triple = uriInfo.triples.find(
+    ({ predicate }) => predicate === MU_UUID_URL
+  );
+
+  return triple?.object?.value;
+}
+
+class ResourceNotFoundError extends Error {
+  constructor(errorMessage, resourceUri) {
+    super(errorMessage);
+    this.resourceUri = resourceUri;
+  }
+}
+
+class RedirectHandlerNotFoundError extends Error {
+  constructor(errorMessage, { type, uuid, resourceUri }) {
+    super(errorMessage);
+    this.type = type;
+    this.uuid = uuid;
+    this.resourceUri = resourceUri;
+  }
+}

--- a/app/services/uri-info.js
+++ b/app/services/uri-info.js
@@ -1,0 +1,62 @@
+import Service from '@ember/service';
+import fetch from 'fetch';
+import config from 'frontend-contact-hub/config/environment';
+import { assert } from '@ember/debug';
+
+/**
+ * Service which interacts with the mu-uri-info-service microservice:
+ *
+ * https://github.com/redpencilio/mu-uri-info-service
+ */
+export default class UriInfoService extends Service {
+  async getAllLinks(subject) {
+    validateSubject(subject);
+
+    return await this._getInfo(this._buildUrl({ subject }));
+  }
+
+  async getDirectLinks(subject, page, pageSize) {
+    validateSubject(subject);
+
+    return await this._getInfo(
+      this._buildUrl({ path: '/direct', subject, page, pageSize })
+    );
+  }
+
+  async getInverseLinks(subject, page, pageSize) {
+    validateSubject(subject);
+
+    return await this._getInfo(
+      this._buildUrl({ path: '/inverse', subject, page, pageSize })
+    );
+  }
+
+  _buildUrl({ path = '', subject, page, pageSize }) {
+    assert(
+      '`uriInfoServiceUrl` needs to be configured in the config/environment.js file',
+      typeof config.uriInfoServiceUrl === 'string'
+    );
+
+    let url = `${config.uriInfoServiceUrl}${path}?subject=${subject}`;
+
+    if (page) {
+      url += `&pageNumber=${page}`;
+    }
+
+    if (pageSize) {
+      url += `&pageSize=${pageSize}`;
+    }
+
+    return url;
+  }
+
+  async _getInfo(url) {
+    let response = await fetch(url);
+
+    return await response.json();
+  }
+}
+
+function validateSubject(subject) {
+  assert('uri-info: subject is required', typeof subject === 'string');
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -41,6 +41,7 @@ module.exports = function (environment) {
     },
 
     showAppVersionHash: process.env.SHOW_APP_VERSION_HASH === 'true',
+    uriInfoServiceUrl: '/uri-info',
 
     userManual: {
       general:

--- a/tests/unit/routes/redirect-test.js
+++ b/tests/unit/routes/redirect-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | redirect', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:redirect');
+    assert.ok(route);
+  });
+});

--- a/tests/unit/services/deep-link-test.js
+++ b/tests/unit/services/deep-link-test.js
@@ -1,0 +1,49 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import RedirectHandler from 'frontend-contact-hub/redirect-handlers/redirect-handler';
+import Service from '@ember/service';
+
+module('Unit | Service | deep-link', function (hooks) {
+  setupTest(hooks);
+
+  test('it uses the correct RedirectHandler based on the type of a resource', async function (assert) {
+    assert.expect(2);
+
+    let deepLink = this.owner.lookup('service:deep-link');
+    deepLink.REDIRECT_HANDLER = {
+      'http://data.test/vocabularies/test': 'test',
+    };
+
+    this.owner.register(
+      'redirect-handler:test',
+      class extends RedirectHandler {
+        redirect(uuid, resourceUri) {
+          assert.equal(uuid, '12345');
+          assert.equal(resourceUri, 'http://data.test/12345');
+        }
+      }
+    );
+
+    this.owner.register(
+      'service:uri-info',
+      class MockUriInfoService extends Service {
+        async getDirectLinks() {
+          return {
+            triples: [
+              {
+                predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+                object: { value: 'http://data.test/vocabularies/test' },
+              },
+              {
+                predicate: 'http://mu.semte.ch/vocabularies/core/uuid',
+                object: { value: '12345' },
+              },
+            ],
+          };
+        }
+      }
+    );
+
+    await deepLink.redirect('http://data.test/12345');
+  });
+});

--- a/tests/unit/services/uri-info-test.js
+++ b/tests/unit/services/uri-info-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | uri-info', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:uri-info');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
This implements direct linking to people and "worship administrative units".

It can be tested by using the following url: `http://localhost:4200/redirect?resource=add-resource-uri-here`

If the type of the resource is supported it should go to the correct page, else it will show the index page instead for now.

Requires this branch in the backend app: https://github.com/lblod/app-contact-hub/pull/57