### PR TITLE
Show the required field info label on the sites pages

### DIFF
--- a/app/templates/administrative-units/administrative-unit/sites/new.hbs
+++ b/app/templates/administrative-units/administrative-unit/sites/new.hbs
@@ -55,7 +55,7 @@
           </:card>
         </EditCard>
 
-        <EditCard>
+        <EditCard @containsRequiredFields={{true}}>
           <:title>Contactgegevens</:title>
           <:card as |Card|>
             <Card.Columns>

--- a/app/templates/administrative-units/administrative-unit/sites/site/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/sites/site/edit.hbs
@@ -63,7 +63,7 @@
           </:card>
         </EditCard>
 
-        <EditCard>
+        <EditCard @containsRequiredFields={{true}}>
           <:title>Contactgegevens</:title>
           <:card as |Card|>
             <Card.Columns>


### PR DESCRIPTION
It seems we missed this before.