### PR TITLE
Add a fallback for the governing body page for newly created administrative units

### DIFF
--- a/app/routes/administrative-units/administrative-unit/governing-bodies.js
+++ b/app/routes/administrative-units/administrative-unit/governing-bodies.js
@@ -22,12 +22,16 @@ export default class AdministrativeUnitsAdministrativeUnitGoverningBodiesRoute e
     //worship services related administrative units only have one governing body and many nested governing bodies "has-time-specializations"
     let governingBody = await administrativeUnit.governingBodies.firstObject;
 
-    let governingBodies = await governingBody.hasTimeSpecializations;
+    // TODO: at the moment new administrative units don't have a governingBody set so this route breaks without this workaround
+    // Remove this once we have a proper plan for newly created administrative units
+    let governingBodies = governingBody
+      ? await governingBody.hasTimeSpecializations
+      : [];
 
     return {
       administrativeUnit,
       governingBodies,
-      governingBodyClassification: await governingBody.classification,
+      governingBodyClassification: await governingBody?.classification,
     };
   }
 }


### PR DESCRIPTION
Newly created administrative units don't have a governing body at the moment which makes the logic in the model hook fail.