### PR TITLE
Add links to SharePoint

### DIFF
--- a/app/controllers/administrative-units/administrative-unit/core-data/index.js
+++ b/app/controllers/administrative-units/administrative-unit/core-data/index.js
@@ -1,0 +1,29 @@
+import { helper } from '@ember/component/helper';
+import Controller from '@ember/controller';
+import { ID_NAME } from 'frontend-contact-hub/models/identifier';
+import WorshipServiceModel from 'frontend-contact-hub/models/worship-service';
+
+const SHAREPOINT_LINK_BASE = {
+  WORSHIP_SERVICE:
+    'https://vlaamseoverheid.sharepoint.com/sites/Abb-Erediensten/Lists/Lijst%20Eredienstbesturen/AllItems.aspx?view=7&q=',
+  CENTRAL_WORSHIP_SERVICE:
+    'https://vlaamseoverheid.sharepoint.com/sites/Abb-Erediensten/Lists/Lijst%20CKB1/AllItems.aspx?view=7&q=',
+};
+
+export default class AdministrativeUnitsAdministrativeUnitCoreDataIndexController extends Controller {
+  isSharePointIdentifier = helper(function isSharePointIdentifier([
+    identifier,
+  ]) {
+    return identifier?.idName === ID_NAME.SHAREPOINT;
+  });
+
+  get isWorshipService() {
+    return this.model.administrativeUnit instanceof WorshipServiceModel;
+  }
+
+  get sharePointLinkBase() {
+    return this.isWorshipService
+      ? SHAREPOINT_LINK_BASE.WORSHIP_SERVICE
+      : SHAREPOINT_LINK_BASE.CENTRAL_WORSHIP_SERVICE;
+  }
+}

--- a/app/templates/administrative-units/administrative-unit/core-data/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/core-data/index.hbs
@@ -75,10 +75,12 @@
             {{#if @model.administrativeUnit.resultedFrom}}
               <Item>
                 <:content>
-                  <AuHelpText @skin="tertiary" class="au-u-margin-top-none">Gewijzigd op
+                  <AuHelpText @skin="tertiary" class="au-u-margin-top-none">
+                    Gewijzigd op
                     {{date-format
                       @model.administrativeUnit.resultedFrom.firstObject.date
-                    }}</AuHelpText>
+                    }}
+                  </AuHelpText>
                 </:content>
               </Item>
             {{/if}}
@@ -86,7 +88,23 @@
               {{#if identifier.structuredIdentifier.localId}}
                 <Item>
                   <:label>{{identifier.idName}}</:label>
-                  <:content>{{identifier.structuredIdentifier.localId}}</:content>
+                  <:content>
+                    {{#let
+                      identifier.structuredIdentifier.localId
+                      as |localId|
+                    }}
+                      {{#if (this.isSharePointIdentifier identifier)}}
+                        <AuLinkExternal
+                          href="{{this.sharePointLinkBase}}{{localId}}"
+                        >
+                          {{localId}}
+                          (externe link)
+                        </AuLinkExternal>
+                      {{else}}
+                        {{localId}}
+                      {{/if}}
+                    {{/let}}
+                  </:content>
                 </Item>
               {{/if}}
             {{/each}}
@@ -138,7 +156,8 @@
                     class="au-c-link"
                     target="_blank"
                     rel="noopener noreferrer"
-                  >{{@model.administrativeUnit.primarySite.contacts.firstObject.website}} (externe link)</a>
+                  >{{@model.administrativeUnit.primarySite.contacts.firstObject.website}}
+                    (externe link)</a>
                 </:content>
               </Item>
             {{/if}}


### PR DESCRIPTION
This adds SharePoint links to the worship administrative unit details page. This allows users to more easily verify if the data was imported correctly.