### PR TITLE
Show the existing address in the address search box

### DIFF
--- a/app/components/address-register-selector.js
+++ b/app/components/address-register-selector.js
@@ -11,16 +11,17 @@ export default class AddressRegisterSelectorComponent extends Component {
 
   sourceCrab;
 
-  get isDisabledBusNumberSelect() {
-    return !this.addressWithBusNumber;
-  }
-
   constructor() {
     super(...arguments);
+
     if (this.args.address) {
-      this.addressSuggestion = this.addressRegister.toAddressSuggestion(
+      let addressSuggestion = this.addressRegister.toAddressSuggestion(
         this.args.address
       );
+
+      if (!addressSuggestion.isEmpty()) {
+        this.addressSuggestion = addressSuggestion;
+      }
     }
   }
 

--- a/app/components/address-search.hbs
+++ b/app/components/address-search.hbs
@@ -10,6 +10,7 @@
       <:content as |errorMessage|>
         <AddressRegisterSelector
           @id="{{id}}-address-search"
+          @address={{@address}}
           @onChange={{this.handleAddressChange}}
           @error={{errorMessage}}
         />

--- a/app/components/address-search.js
+++ b/app/components/address-search.js
@@ -27,16 +27,6 @@ export default class AddressSearchComponent extends Component {
     super(...arguments);
 
     this.detectInitialInputMode();
-
-    if (this.isAddressSearchMode) {
-      let addressWithBusNumber = this.addressRegister.toAddressSuggestion(
-        this.args.address
-      );
-
-      if (!addressWithBusNumber.isEmpty()) {
-        this.addressWithBusNumber = addressWithBusNumber;
-      }
-    }
   }
 
   @action


### PR DESCRIPTION
I missed this in the PR. The address data wasn't visible when in "search mode" which is confusing. Now it shows the existing address data.