### PR TITLE
Make the Card::Item label optional

### DIFF
--- a/app/components/address-search.hbs
+++ b/app/components/address-search.hbs
@@ -55,8 +55,6 @@
     {{yield to="manual-address-input"}}
 
     <Item>
-      {{! TODO: Add a placeholder to the Item component so we don't output a label element if it's not needed }}
-      <:label>&nbsp;</:label>
       <:content>
         <AuButton @skin="link" {{on "click" this.toggleInputMode}}>
           Vind adres in lijst

--- a/app/components/data-card/item.hbs
+++ b/app/components/data-card/item.hbs
@@ -1,5 +1,7 @@
 <div
-  class="au-c-card-item {{if @alignTop "au-c-card-grid-item--align-top"}} {{if @isGrid "au-o-grid__item au-u-1-2@medium"}}"
+  class="au-c-card-item
+    {{if @alignTop "au-c-card-grid-item--align-top"}}
+    {{if @isGrid "au-o-grid__item au-u-1-2@medium"}}"
   ...attributes
 >
   {{#if (has-block "label")}}
@@ -9,7 +11,11 @@
   {{/if}}
 
   {{#if (has-block "content")}}
-    <dd class="au-c-card-item__content au-u-word-break">
+    <dd
+      class="au-c-card-item__content au-u-word-break
+        {{if (not (has-block "label")) "au-c-card-item__content--offset"}}
+        "
+    >
       {{yield to="content"}}
     </dd>
   {{/if}}

--- a/app/components/edit-card/item.hbs
+++ b/app/components/edit-card/item.hbs
@@ -20,7 +20,11 @@
   {{/if}}
 
   {{#if (has-block "content")}}
-    <div class="au-c-card-item__content">
+    <div
+      class="au-c-card-item__content
+        {{if (not (has-block "label")) "au-c-card-item__content--offset"}}
+      "
+    >
       {{yield @errorMessage to="content"}}
 
       {{#if @errorMessage}}

--- a/app/styles/components/_cards.scss
+++ b/app/styles/components/_cards.scss
@@ -3,6 +3,9 @@
    Extends the default appuniversum card component
    ================================== */
 
+$card-label-width: 20rem; // This has to be wide enough to fit all labels properly
+$card-label-whitespace: $au-unit-small;
+
 // Read-only card
 .au-c-card--data {
   border-color: $au-gray-100;
@@ -54,8 +57,9 @@
   width: 100%;
 
   @include mq(small) {
-    flex-basis: 20rem; // This has to be wide enough to fit all labels properly
+    flex-basis: $card-label-width;
     flex-shrink: 0;
+    margin-right: $card-label-whitespace;
   }
 }
 
@@ -66,8 +70,6 @@
 
 .au-c-card-item__label--edit {
   @include mq(small) {
-    margin-right: $au-unit-small;
-
     .au-c-label {
       margin-bottom: 0;
     }
@@ -80,5 +82,11 @@
   @include mq(small) {
     flex-shrink: 1;
     flex-grow: 1;
+  }
+}
+
+.au-c-card-item__content--offset {
+  @include mq(small) {
+    margin-left: $card-label-width + $card-label-whitespace;
   }
 }

--- a/app/templates/administrative-units/administrative-unit/core-data/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/core-data/index.hbs
@@ -74,7 +74,6 @@
             {{! TODO: Take the last date from the change events }}
             {{#if @model.administrativeUnit.resultedFrom}}
               <Item>
-                <:label></:label>
                 <:content>
                   <AuHelpText @skin="tertiary" class="au-u-margin-top-none">Gewijzigd op
                     {{date-format

--- a/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/mandatory/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/mandatory/edit.hbs
@@ -241,7 +241,6 @@
                   </:content>
                 </Item>
                 <Item>
-                  <:label>{{! No label }}</:label>
                   <:content>
                     <AuControlCheckbox
                       checked={{this.isCurrentPosition}}

--- a/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/mandatory/new.hbs
+++ b/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/mandatory/new.hbs
@@ -245,8 +245,6 @@
                 </:content>
               </Item>
               <Item>
-                <:label
-                >{{! TODO: remove this once the component supports a placeholder}}</:label>
                 <:content>
                   <AuControlCheckbox
                     checked={{this.isCurrentPosition}}

--- a/app/templates/administrative-units/administrative-unit/ministers/new.hbs
+++ b/app/templates/administrative-units/administrative-unit/ministers/new.hbs
@@ -206,7 +206,6 @@
                 </:content>
               </Item>
               <Item>
-                <:label>{{! No label }}</:label>
                 <:content>
                   <AuControlCheckbox
                     checked={{this.isCurrentPosition}}

--- a/app/templates/organizations/organization/index.hbs
+++ b/app/templates/organizations/organization/index.hbs
@@ -32,7 +32,6 @@
             {{! TODO: Take the last date from the change events }}
             {{#if @model.representativeBody.resultedFrom}}
               <Item>
-                <:label></:label>
                 <:content>
                   <AuHelpText @skin="tertiary">Gewijzigd op
                     {{date-format

--- a/app/templates/people/person/positions/minister/edit.hbs
+++ b/app/templates/people/person/positions/minister/edit.hbs
@@ -188,7 +188,6 @@
                 </:content>
               </Item>
               <Item @labelFor="end-date">
-                <:label>{{! No label }}</:label>
                 <:content>
                   <AuControlCheckbox
                     checked={{this.isCurrentPosition}}


### PR DESCRIPTION
The label isn't always needed and this allows us to remove the empty label elements that we used as a workaround.