### PR TITLE
Use 'history' instead of 'auto'

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function (environment) {
     modulePrefix: 'frontend-contact-hub',
     environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'history',
     yasgui: {
       defaultQuery: '{{YASGUI_DEFAULT_QUERY}}',
       extraPrefixes: '{{YASGUI_EXTRA_PREFIXES}}',


### PR DESCRIPTION
The 'AutoLocation' class is used by default and is needed to support older browsers that don't have access to the History api. We don't need to support old browsers so we can use the 'HistoryLocation' class instead. 'AutoLocation' will also be deprecated soon.