### PR TITLE
Fix a problem which prevents users from entering the core data edit page

### DIFF
--- a/app/routes/administrative-units/administrative-unit/core-data/edit.js
+++ b/app/routes/administrative-units/administrative-unit/core-data/edit.js
@@ -72,9 +72,9 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditRoute exte
 
         identifier.structuredIdentifier = structuredIdentifier;
         missingIdentifiers.push(identifier);
-
-        return missingIdentifiers;
       }
+
+      return missingIdentifiers;
     }, []);
   }
 }


### PR DESCRIPTION
We have logic in place that creates missing identifiers when entering the edit page. This logic wasn't working correctly which sometimes causes an exception during the route transition.