### PR TITLE
Province is a required field on some pages

### DIFF
--- a/app/components/address-search.hbs
+++ b/app/components/address-search.hbs
@@ -42,18 +42,18 @@
             "Geen busnummer beschikbaar"
           }}
         />
-
         {{#if this.selectedAddress}}
           <AuHelpText>
             Staat het correcte busnummer niet in de lijst?
-            <AuLinkExternal href="mailto:{{config "contactEmail"}}">Mail ons</AuLinkExternal>
+            <AuLinkExternal href="mailto:{{config " contactEmail"}}">Mail ons</AuLinkExternal>
           </AuHelpText>
         {{/if}}
       </:content>
     </Item>
+   {{yield to="common-input"}}
   {{else}}
     {{yield to="manual-address-input"}}
-
+    {{yield to="common-input"}}
     <Item>
       <:content>
         <AuButton @skin="link" {{on "click" this.toggleInputMode}}>

--- a/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
@@ -262,7 +262,13 @@
                         />
                       </:content>
                     </Item>
-                    <Item @labelFor="primary-site-address-province">
+                  </:manual-address-input>
+                  <:common-input>
+                    <Item
+                      @labelFor="primary-site-address-province"
+                      @required={{true}}
+                      @errorMessage={{@model.address.error.province.validation}}
+                    >
                       <:label>Provincie</:label>
                       <:content as |hasError|>
                         <ProvinceSelect
@@ -273,7 +279,7 @@
                         />
                       </:content>
                     </Item>
-                  </:manual-address-input>
+                  </:common-input>
                 </AddressSearch>
               </:left>
               <:right as |Item|>

--- a/app/templates/administrative-units/administrative-unit/sites/new.hbs
+++ b/app/templates/administrative-units/administrative-unit/sites/new.hbs
@@ -137,6 +137,8 @@
                         />
                       </:content>
                     </Item>
+                  </:manual-address-input>
+                  <:common-input>
                     <Item
                       @labelFor="site-address-province"
                       @required={{true}}
@@ -152,7 +154,7 @@
                         />
                       </:content>
                     </Item>
-                  </:manual-address-input>
+                  </:common-input>
                 </AddressSearch>
               </:left>
               <:right as |Item|>

--- a/app/templates/administrative-units/administrative-unit/sites/site/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/sites/site/edit.hbs
@@ -150,6 +150,8 @@
                         />
                       </:content>
                     </Item>
+                  </:manual-address-input>
+                  <:common-input>
                     <Item
                       @labelFor="site-address-province"
                       @required={{true}}
@@ -165,7 +167,7 @@
                         />
                       </:content>
                     </Item>
-                  </:manual-address-input>
+                  </:common-input>
                 </AddressSearch>
               </:left>
               <:right as |Item|>

--- a/app/templates/administrative-units/new.hbs
+++ b/app/templates/administrative-units/new.hbs
@@ -252,7 +252,13 @@
                     />
                   </:content>
                 </Item>
-                <Item @labelFor="primary-site-address-province">
+              </:manual-address-input>
+              <:common-input>
+                <Item
+                  @labelFor="primary-site-address-province"
+                  @required={{true}}
+                  @errorMessage={{@model.address.error.province.validation}}
+                >
                   <:label>Provincie</:label>
                   <:content as |hasError|>
                     <ProvinceSelect
@@ -263,7 +269,7 @@
                     />
                   </:content>
                 </Item>
-              </:manual-address-input>
+              </:common-input>
             </AddressSearch>
           </:left>
           <:right as |Item|>

--- a/app/validations/address.js
+++ b/app/validations/address.js
@@ -2,8 +2,8 @@ import { validatePresence } from 'ember-changeset-validations/validators';
 
 export function getAddressValidations(isAlwaysRequired = false) {
   const REQUIRED_MESSAGE = 'Vul het volledige adres in';
-
-  return {
+  let isProvinceRequired = isAlwaysRequired;
+  let addressValidation = {
     street: validatePresence({
       presence: true,
       ignoreBlank: true,
@@ -37,4 +37,12 @@ export function getAddressValidations(isAlwaysRequired = false) {
         : ['street', 'number', 'postcode', 'province'],
     }),
   };
+  if (isProvinceRequired) {
+    addressValidation.province = validatePresence({
+      presence: true,
+      ignoreBlank: true,
+      message: REQUIRED_MESSAGE,
+    });
+  }
+  return addressValidation;
 }


### PR DESCRIPTION
When integrating CRAB we removed the requirement to fill in a province since this information is not provided by CRAB. End users still expect the province to be there for administrative units since they can filter the search using that data. So this adds back the requirement for certain pages.