### PR TITLE
Implement the change event overview page

### DIFF
--- a/app/controllers/administrative-units/administrative-unit/change-events/index.js
+++ b/app/controllers/administrative-units/administrative-unit/change-events/index.js
@@ -1,0 +1,10 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+
+export default class AdministrativeUnitsAdministrativeUnitChangeEventsIndexController extends Controller {
+  queryParams = ['page', 'size', 'sort'];
+
+  @tracked page = 0;
+  @tracked size = 20;
+  @tracked sort = '-result-from.date';
+}

--- a/app/models/change-event-result.js
+++ b/app/models/change-event-result.js
@@ -1,0 +1,13 @@
+import Model, { belongsTo } from '@ember-data/model';
+
+export default class ChangeEventResultModel extends Model {
+  @belongsTo('organization-status-code', {
+    inverse: null,
+  })
+  status;
+
+  @belongsTo('change-event', { inverse: 'results' }) resultFrom;
+
+  @belongsTo('organization', { inverse: 'changeEventResults' })
+  resultingOrganization;
+}

--- a/app/models/change-event.js
+++ b/app/models/change-event.js
@@ -1,4 +1,4 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class ChangeEventModel extends Model {
   @attr('date') date;
@@ -8,4 +8,19 @@ export default class ChangeEventModel extends Model {
     inverse: null,
   })
   type;
+
+  @hasMany('organization', {
+    inverse: 'resultedFrom',
+  })
+  resultingOrganization;
+
+  @hasMany('organization', {
+    inverse: 'changedBy',
+  })
+  originalOrganization;
+
+  @hasMany('change-event-result', {
+    inverse: 'resultFrom',
+  })
+  results;
 }

--- a/app/models/organization.js
+++ b/app/models/organization.js
@@ -25,12 +25,12 @@ export default class OrganizationModel extends Model {
   sites;
 
   @hasMany('change-event', {
-    inverse: null,
+    inverse: 'originalOrganization',
   })
   changedBy;
 
   @hasMany('change-event', {
-    inverse: null,
+    inverse: 'resultingOrganization',
   })
   resultedFrom;
 

--- a/app/models/organization.js
+++ b/app/models/organization.js
@@ -34,6 +34,11 @@ export default class OrganizationModel extends Model {
   })
   resultedFrom;
 
+  @hasMany('change-event-result', {
+    inverse: 'resultingOrganization',
+  })
+  changeEventResults;
+
   @hasMany('post', {
     inverse: null,
   })

--- a/app/router.js
+++ b/app/router.js
@@ -78,6 +78,11 @@ Router.map(function () {
             this.route('edit');
           }
         );
+        this.route(
+          'change-events',
+          { path: '/veranderingsgebeurtenissen' },
+          function () {}
+        );
       });
       this.route('new', { path: '/nieuwe-bestuurseenheid' });
     }

--- a/app/routes/administrative-units/administrative-unit/change-events.js
+++ b/app/routes/administrative-units/administrative-unit/change-events.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class AdministrativeUnitsAdministrativeUnitChangeEventsRoute extends Route {}

--- a/app/routes/administrative-units/administrative-unit/change-events/index.js
+++ b/app/routes/administrative-units/administrative-unit/change-events/index.js
@@ -1,0 +1,35 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class AdministrativeUnitsAdministrativeUnitChangeEventsIndexRoute extends Route {
+  @service store;
+
+  queryParams = {
+    page: { refreshModel: true },
+    size: { refreshModel: true },
+    sort: { refreshModel: true },
+  };
+
+  async model(params) {
+    let { id: administrativeUnitId } = this.paramsFor(
+      'administrative-units.administrative-unit'
+    );
+
+    let changeEventResults = await this.store.query('change-event-result', {
+      'filter[resulting-organization][:id:]': administrativeUnitId,
+      include: ['result-from.type', 'status', 'resulting-organization'].join(),
+      page: {
+        number: params.page,
+        size: params.size,
+      },
+      sort: params.sort,
+    });
+
+    return {
+      administrativeUnit: this.modelFor(
+        'administrative-units.administrative-unit'
+      ),
+      changeEventResults,
+    };
+  }
+}

--- a/app/templates/administrative-units/administrative-unit.hbs
+++ b/app/templates/administrative-units/administrative-unit.hbs
@@ -46,14 +46,14 @@
             </AuNavigationNestedLink>
           </li>
         {{/if}}
+        <li class="au-c-list-navigation__item">
+          <AuNavigationNestedLink
+            @route="administrative-units.administrative-unit.change-events"
+          >
+            Veranderingsgebeurtenissen
+          </AuNavigationNestedLink>
+        </li>
         {{!--         Links temporarily hidden until page is completed
-        {{#if (not-eq @model.constructor.modelName "central-worship-service")}}
-          <li class="au-c-list-navigation__item">
-            <AuNavigationNestedLink>
-              Veranderingsgebeurtenissen
-            </AuNavigationNestedLink>
-          </li>
-        {{/if}}
         <li class="au-c-list-navigation__item">
           <AuNavigationNestedLink>
             Documenten

--- a/app/templates/administrative-units/administrative-unit/change-events.hbs
+++ b/app/templates/administrative-units/administrative-unit/change-events.hbs
@@ -1,0 +1,9 @@
+{{page-title "Veranderingsgebeurtenissen"}}
+
+{{breadcrumb
+  "Veranderingsgebeurtenissen"
+  route="administrative-units.administrative-unit.change-events"
+  model=(params-for "administrative-units.administrative-unit" param="id")
+}}
+
+{{outlet}}

--- a/app/templates/administrative-units/administrative-unit/change-events/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/change-events/index.hbs
@@ -1,0 +1,51 @@
+<PageHeader class="au-o-box">
+  <:title>Veranderingsgebeurtenissen</:title>
+  <:subtitle>{{@model.administrativeUnit.name}}</:subtitle>
+</PageHeader>
+
+<AuDataTable
+  @content={{@model.changeEventResults}}
+  @noDataMessage="Geen veranderingsgebeurtenissen"
+  @isLoading={{this.showTableLoader}}
+  @page={{this.page}}
+  @size={{this.size}}
+  as |t|
+>
+  <t.content as |c|>
+    <c.header>
+      <AuDataTableThSortable
+        @field="result-from.type.label"
+        @currentSorting={{this.sort}}
+        @label="Type veranderingsgebeurtenis"
+      />
+      <AuDataTableThSortable
+        @field="result-from.date"
+        @currentSorting={{this.sort}}
+        @label="Datum"
+      />
+      <AuDataTableThSortable
+        @field="result-from.description"
+        @currentSorting={{this.sort}}
+        @label="Beschrijving"
+      />
+      <AuDataTableThSortable
+        @field="status.label"
+        @currentSorting={{this.sort}}
+        @label="Resulterende status"
+      />
+    </c.header>
+    <c.body as |changeEventResult|>
+      {{#let changeEventResult.resultFrom as |changeEvent|}}
+        <td>
+          {{! TODO: Replace this with a link to the "details" route once it is created }}
+          {{changeEvent.type.label}}
+        </td>
+        <td>{{date-format changeEvent.date}}</td>
+        <td>{{changeEvent.description}}</td>
+        <td>
+          <OrganizationStatus @status={{changeEventResult.status}} />
+        </td>
+      {{/let}}
+    </c.body>
+  </t.content>
+</AuDataTable>


### PR DESCRIPTION
Targeting the `feature/change-events-management` branch instead of `development` so that we can merge and deploy that branch when the database is migrated.

It requires this branch in the backend: https://github.com/lblod/app-contact-hub/pull/75