### PR TITLE
Fix "Mail ons" link in the address search functionality

### DIFF
--- a/app/components/address-search.hbs
+++ b/app/components/address-search.hbs
@@ -45,7 +45,7 @@
         {{#if this.selectedAddress}}
           <AuHelpText>
             Staat het correcte busnummer niet in de lijst?
-            <AuLinkExternal href="mailto:{{config " contactEmail"}}">Mail ons</AuLinkExternal>
+            <AuLinkExternal href="mailto:{{config "contactEmail"}}">Mail ons</AuLinkExternal>
           </AuHelpText>
         {{/if}}
       </:content>


### PR DESCRIPTION
The link wasn't working correctly so clicking it didn't prefill the email field with the correct address.