### PR TITLE
Use GITHUB_AUTH for release-it

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,6 +1,7 @@
 {
   "github": {
-    "release": true
+    "release": true,
+    "tokenRef": "GITHUB_AUTH"
   },
   "npm": {
     "publish": false


### PR DESCRIPTION
GITHUB_AUTH is also used by lerna-changelog so this means only 1 token needs to be added to the command.

More information can be found on [the release-it automated Github release guide](https://github.com/release-it/release-it/blob/master/docs/github-releases.md#automated).