### PR TITLE
Pluralize the hasMany relationship names

### DIFF
--- a/app/models/change-event.js
+++ b/app/models/change-event.js
@@ -17,12 +17,12 @@ export default class ChangeEventModel extends Model {
   @hasMany('organization', {
     inverse: 'resultedFrom',
   })
-  resultingOrganization;
+  resultingOrganizations;
 
   @hasMany('organization', {
     inverse: 'changedBy',
   })
-  originalOrganization;
+  originalOrganizations;
 
   @hasMany('change-event-result', {
     inverse: 'resultFrom',

--- a/app/models/organization.js
+++ b/app/models/organization.js
@@ -25,12 +25,12 @@ export default class OrganizationModel extends Model {
   sites;
 
   @hasMany('change-event', {
-    inverse: 'originalOrganization',
+    inverse: 'originalOrganizations',
   })
   changedBy;
 
   @hasMany('change-event', {
-    inverse: 'resultingOrganization',
+    inverse: 'resultingOrganizations',
   })
   resultedFrom;
 

--- a/app/routes/administrative-units/administrative-unit/change-events/details/index.js
+++ b/app/routes/administrative-units/administrative-unit/change-events/details/index.js
@@ -21,8 +21,8 @@ export default class AdministrativeUnitsAdministrativeUnitChangeEventsDetailsInd
         include: [
           'type',
           'decision',
-          'original-organization',
-          'resulting-organization',
+          'original-organizations',
+          'resulting-organizations',
           'results.resulting-organization',
           'results.status',
         ].join(),

--- a/app/templates/administrative-units/administrative-unit/change-events/details/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/change-events/details/index.hbs
@@ -87,7 +87,7 @@
           <Card.Columns>
             <:left as |Item|>
               {{#each
-                @model.changeEvent.originalOrganization
+                @model.changeEvent.originalOrganizations
                 as |organization|
               }}
                 <Item>
@@ -110,9 +110,9 @@
                   <:content>
                     <AuLink
                       @route="administrative-units.administrative-unit"
-                      @model={{@model.changeEvent.resultingOrganization.firstObject.id}}
+                      @model={{@model.changeEvent.resultingOrganizations.firstObject.id}}
                     >
-                      {{@model.changeEvent.resultingOrganization.firstObject.name}}
+                      {{@model.changeEvent.resultingOrganizations.firstObject.name}}
                     </AuLink>
                   </:content>
                 </Item>


### PR DESCRIPTION
The previous naming was confusing since it implied that it was a 1 to 1 relationship.