### PR TITLE
Add a `requireEditPermissions` method to the currentSession service

### DIFF
--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -10,6 +10,7 @@ const EDITOR_ROLES = [
 const READER_ROLES = ['ABBOrganisatiePortaalGebruiker-lezer'];
 
 export default class CurrentSessionService extends Service {
+  @service router;
   @service session;
   @service store;
 
@@ -17,6 +18,16 @@ export default class CurrentSessionService extends Service {
   @tracked user;
   @tracked group;
   @tracked roles;
+
+  get canEdit() {
+    return this.roles.some((role) => EDITOR_ROLES.includes(role));
+  }
+
+  get canOnlyRead() {
+    return (
+      !this.canEdit && this.roles.some((role) => READER_ROLES.includes(role))
+    );
+  }
 
   async load() {
     if (this.session.isAuthenticated) {
@@ -35,13 +46,61 @@ export default class CurrentSessionService extends Service {
     }
   }
 
-  get canEdit() {
-    return this.roles.some((role) => EDITOR_ROLES.includes(role));
+  /**
+   * Checks if the user has edit permissions and if they do not,
+   * transition to the 'route-not-found' page while keeping the
+   * same url as the target route.
+   *
+   * @param {Transition} transition
+   * @returns {boolean} true if the user has edit permissions, false otherwise
+   */
+  requireEditPermissions(transition) {
+    if (this.canEdit) {
+      return true;
+    }
+
+    this.router.replaceWith('route-not-found', {
+      wildcard: generateWildcardUrl(transition, this.router),
+    });
+
+    return false;
+  }
+}
+
+/**
+ * Generate a url for the destination route without the leading slash so that it can be passed into the wildcard.
+ * Ideally this url would be provided by the transition object but that isn't the case at the moment.
+ * `transition.intent.url` does exist but that is considered private API.
+ *
+ * Discord discussion about a potential RFC: https://discord.com/channels/480462759797063690/624403666585124895/897832626616926218
+ *
+ * @param {Transition} transition
+ * @param {RouterService} routerService
+ * @returns {string} url without a leading slash `/` so that it can be passed into the wildcard directly.
+ */
+function generateWildcardUrl(transition, routerService) {
+  let targetRoute = transition.to.name;
+  let allRouteParamValues = [];
+  let allRouteQueryParams = {};
+
+  transition.to.find((routeInfo) => {
+    routeInfo.paramNames.forEach((paramName) => {
+      let paramValue = routeInfo.params[paramName];
+      allRouteParamValues.push(paramValue);
+      allRouteQueryParams = {
+        ...allRouteQueryParams,
+        ...routeInfo.queryParams,
+      };
+    });
+  });
+
+  let generatedUrl = routerService.urlFor(targetRoute, ...allRouteParamValues, {
+    queryParams: allRouteQueryParams,
+  });
+
+  if (generatedUrl.startsWith('/')) {
+    generatedUrl = generatedUrl.slice(1);
   }
 
-  get canOnlyRead() {
-    return (
-      !this.canEdit && this.roles.some((role) => READER_ROLES.includes(role))
-    );
-  }
+  return generatedUrl;
 }


### PR DESCRIPTION
This method can be used to automatically redirect users to the `route-not-found` page if they don't have the needed permissions. It works very similar to ember-simple-auth's `requireAuthentication` method. 

This version has the benefit that the url doesn't change to "/pagina-niet-gevonden" so it works similar to traditional websites.

Usage:
```diff
  beforeModel() {
-    if (!this.currentSession.canEdit) {
-      this.router.transitionTo('route-not-found', {
-        wildcard: 'pagina-niet-gevonden',
-      });
-    }
+    this.currentSession.requireEditPermissions(transition);
  }
```

This can be rolled out to all the pages that need it if we want.