### PR TITLE
Some small change event improvements

### DIFF
--- a/app/controllers/administrative-units/administrative-unit/change-events/new.js
+++ b/app/controllers/administrative-units/administrative-unit/change-events/new.js
@@ -145,6 +145,15 @@ export default class AdministrativeUnitsAdministrativeUnitChangeEventsNewControl
       );
     }
   }
+
+  reset() {
+    this.removeUnsavedRecords();
+  }
+
+  removeUnsavedRecords() {
+    this.model.changeEventRecord.rollbackAttributes();
+    this.model.decisionRecord.rollbackAttributes();
+  }
 }
 
 async function createChangeEventResult({

--- a/app/controllers/administrative-units/administrative-unit/change-events/new.js
+++ b/app/controllers/administrative-units/administrative-unit/change-events/new.js
@@ -49,16 +49,27 @@ export default class AdministrativeUnitsAdministrativeUnitChangeEventsNewControl
 
     const { changeEvent, decision, formState } = this.model;
 
+    let shouldSaveDecision = formState.canAddDecisionInformation;
+
     yield formState.validate();
     yield changeEvent.validate();
-    yield decision.validate();
 
-    if (formState.isValid && decision.isValid && changeEvent.isValid) {
-      yield decision.save();
+    if (shouldSaveDecision) {
+      yield decision.validate();
+    }
+
+    if (
+      formState.isValid &&
+      (shouldSaveDecision ? decision.isValid : true) &&
+      changeEvent.isValid
+    ) {
+      if (shouldSaveDecision) {
+        yield decision.save();
+        changeEvent.decision = decision;
+      }
 
       let changeEventType = formState.changeEventType;
       changeEvent.type = changeEventType;
-      changeEvent.decision = decision;
       yield changeEvent.save();
 
       if (changesMultipleOrganizations(changeEventType)) {

--- a/app/routes/administrative-units/administrative-unit/change-events/details/edit.js
+++ b/app/routes/administrative-units/administrative-unit/change-events/details/edit.js
@@ -26,17 +26,23 @@ export default class AdministrativeUnitsAdministrativeUnitChangeEventsDetailsEdi
     );
 
     let changeEventType = await changeEvent.type;
-    let decision = await changeEvent.decision;
+    let canAddDecisionInformation =
+      changeEventType.id !== CHANGE_EVENT_TYPE.RECOGNITION_REQUESTED;
 
-    return {
+    let model = {
       ...detailsPageModel,
       changeEvent: createValidatedChangeset(
         changeEvent,
         changeEventValidations
       ),
-      decision: createValidatedChangeset(decision, decisionValidations),
-      canAddDecisionInformation:
-        changeEventType.id !== CHANGE_EVENT_TYPE.RECOGNITION_REQUESTED,
+      canAddDecisionInformation,
     };
+
+    if (canAddDecisionInformation) {
+      let decision = await changeEvent.decision;
+      model.decision = createValidatedChangeset(decision, decisionValidations);
+    }
+
+    return model;
   }
 }

--- a/app/routes/administrative-units/administrative-unit/change-events/new.js
+++ b/app/routes/administrative-units/administrative-unit/change-events/new.js
@@ -38,7 +38,15 @@ export default class AdministrativeUnitsAdministrativeUnitChangeEventsNewRoute e
       ),
       decision: createValidatedChangeset(decision, decisionValidations),
       formState: new FormState({ currentOrganization: administrativeUnit }),
+      changeEventRecord: changeEvent,
+      decisionRecord: decision,
     };
+  }
+
+  resetController(controller) {
+    super.resetController(...arguments);
+
+    controller.reset();
   }
 }
 


### PR DESCRIPTION
I noticed some things were missing in the previous implementations:

- only save decisions if the change event type requires it
- update the edit page so that it doesn't require a decision record if it's not needed
- clean up unsaved records when leaving the creation page