### PR TITLE
Improve the original organizations selection logic on the change events creation page

### DIFF
--- a/app/controllers/administrative-units/administrative-unit/change-events/new.js
+++ b/app/controllers/administrative-units/administrative-unit/change-events/new.js
@@ -81,7 +81,7 @@ export default class AdministrativeUnitsAdministrativeUnitChangeEventsNewControl
       // which is needed when saving the change-event-results
       yield changeEvent.save();
 
-      if (changesMultipleOrganizations(changeEventType)) {
+      if (canChangeMultipleOrganizations(changeEventType)) {
         let allOriginalOrganizations = formState.allOriginalOrganizations;
         changeEvent.originalOrganizations.pushObjects(allOriginalOrganizations);
 
@@ -214,7 +214,7 @@ async function createChangeEventResult({
   await changeEventResult.save();
 }
 
-function changesMultipleOrganizations(changeEventType) {
+function canChangeMultipleOrganizations(changeEventType) {
   return (
     changeEventType.id === CHANGE_EVENT_TYPE.MERGER ||
     changeEventType.id === CHANGE_EVENT_TYPE.AREA_DESCRIPTION_CHANGE

--- a/app/routes/administrative-units/administrative-unit/change-events/new.js
+++ b/app/routes/administrative-units/administrative-unit/change-events/new.js
@@ -80,8 +80,23 @@ class FormState {
   set changeEventType(value) {
     this._changeEventType = value;
 
+    if (
+      this.shouldSelectMultipleOriginalOrganizations &&
+      !this.isAddingOriginalOrganization &&
+      this.originalOrganizations.length === 0
+    ) {
+      this.isAddingOriginalOrganization = true;
+    }
+
     if (this.error?.changeEventType) {
       delete this.error.changeEventType;
+      this.error = {
+        ...this.error,
+      };
+    }
+
+    if (this.error?.originalOrganizations) {
+      delete this.error.originalOrganizations;
       this.error = {
         ...this.error,
       };
@@ -118,6 +133,24 @@ class FormState {
     return (
       changeEventTypeId === CHANGE_EVENT_TYPE.MERGER ||
       changeEventTypeId === CHANGE_EVENT_TYPE.AREA_DESCRIPTION_CHANGE
+    );
+  }
+
+  get shouldSelectMultipleOriginalOrganizations() {
+    return this.changeEventType.id === CHANGE_EVENT_TYPE.MERGER;
+  }
+
+  get canCancelSelectingOriginalOrganization() {
+    return (
+      !this.shouldSelectMultipleOriginalOrganizations ||
+      this.originalOrganizations.length > 0
+    );
+  }
+
+  get canRemoveSelectedOriginalOrganization() {
+    return (
+      !this.shouldSelectMultipleOriginalOrganizations ||
+      this.originalOrganizations.length > 1
     );
   }
 
@@ -199,7 +232,7 @@ class FormState {
     }
 
     if (
-      this.shouldShowExtraInformationCard &&
+      this.shouldSelectMultipleOriginalOrganizations &&
       this.originalOrganizations.length === 0
     ) {
       error.originalOrganizations = {

--- a/app/templates/administrative-units/administrative-unit/change-events/new.hbs
+++ b/app/templates/administrative-units/administrative-unit/change-events/new.hbs
@@ -143,7 +143,7 @@
                         class="grow"
                       />
                       {{#if
-                        (gt @model.formState.originalOrganizations.length 1)
+                        @model.formState.canRemoveSelectedOriginalOrganization
                       }}
                         <AuButton
                           @alert={{true}}
@@ -171,9 +171,9 @@
 
               {{#if @model.formState.isAddingOriginalOrganization}}
                 <Item
-                  @required={{eq
-                    @model.formState.originalOrganizations.length
-                    0
+                  @required={{and
+                    @model.formState.shouldSelectMultipleOriginalOrganizations
+                    (eq @model.formState.originalOrganizations.length 0)
                   }}
                   @errorMessage={{@model.formState.error.originalOrganizations.validation}}
                 >
@@ -188,7 +188,7 @@
                         class="grow"
                       />
                       {{#if
-                        (not-eq @model.formState.originalOrganizations.length 0)
+                        @model.formState.canCancelSelectingOriginalOrganization
                       }}
                         <AuButton
                           @alert={{true}}


### PR DESCRIPTION
Selecting more than 1 original organization is no longer a requirement for the "gebiedswijziging" change event.