### PR TITLE
Fix the SPARQL page

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -20,6 +20,10 @@ module.exports = function (defaults) {
     babel: {
       plugins: [require.resolve('ember-auto-import/babel-plugin')],
     },
+    // Disable chunk css fingerprinting until the config is included in ember-auto-import: https://github.com/ef4/ember-auto-import/pull/496
+    fingerprint: {
+      exclude: ['assets/chunk.*.css'],
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
The page shows a white screen due to missing assets. This is caused by the ember-auto-import 2.4.0 release which outputs css files instead of js with bundled css. The problem is that these css files are fingerprinted by default, which means the filename doesn't match the importmap value.

This adds configuration to make sure the chunked css files aren't fingerprinted.

More information: https://github.com/ef4/ember-auto-import/pull/496/files