### PR TITLE
Fix Edit page when primary contact is null

### DIFF
--- a/app/controllers/people/person/personal-information/edit.js
+++ b/app/controllers/people/person/personal-information/edit.js
@@ -29,8 +29,7 @@ export default class PeoplePersonPersonalInformationEditController extends Contr
 
     if (valid) {
       for (let contact of contacts) {
-        let { primaryContact, secondaryContact, address, _ember_data } =
-          contact;
+        let { primaryContact, secondaryContact, address, _position } = contact;
         if (address.isDirty) {
           address.fullAddress = combineFullAddress(address);
           yield address.save();
@@ -38,15 +37,14 @@ export default class PeoplePersonPersonalInformationEditController extends Contr
         primaryContact.contactAddress = address;
         if (primaryContact.isDirty) {
           yield primaryContact.save();
-          _ember_data.contacts.pushObject(primaryContact);
         }
         if (secondaryContact.isDirty) {
           yield secondaryContact.save();
-          _ember_data.contacts.pushObject(secondaryContact);
         }
-        yield _ember_data.save();
+        yield _position.save();
       }
       yield person.save();
+      this.router.refresh();
       this.router.transitionTo('people.person.personal-information', person.id);
     }
   }

--- a/app/controllers/people/person/personal-information/edit.js
+++ b/app/controllers/people/person/personal-information/edit.js
@@ -29,7 +29,7 @@ export default class PeoplePersonPersonalInformationEditController extends Contr
 
     if (valid) {
       for (let contact of contacts) {
-        let { primaryContact, secondaryContact, address, _position } = contact;
+        let { primaryContact, secondaryContact, address, position } = contact;
         if (address.isDirty) {
           address.fullAddress = combineFullAddress(address);
           yield address.save();
@@ -41,7 +41,7 @@ export default class PeoplePersonPersonalInformationEditController extends Contr
         if (secondaryContact.isDirty) {
           yield secondaryContact.save();
         }
-        yield _position.save();
+        yield position.save();
       }
       yield person.save();
       this.router.refresh();

--- a/app/controllers/people/person/personal-information/edit.js
+++ b/app/controllers/people/person/personal-information/edit.js
@@ -29,7 +29,8 @@ export default class PeoplePersonPersonalInformationEditController extends Contr
 
     if (valid) {
       for (let contact of contacts) {
-        let { primaryContact, secondaryContact, address } = contact;
+        let { primaryContact, secondaryContact, address, _ember_data } =
+          contact;
         if (address.isDirty) {
           address.fullAddress = combineFullAddress(address);
           yield address.save();
@@ -37,13 +38,15 @@ export default class PeoplePersonPersonalInformationEditController extends Contr
         primaryContact.contactAddress = address;
         if (primaryContact.isDirty) {
           yield primaryContact.save();
+          _ember_data.contacts.pushObject(primaryContact);
         }
         if (secondaryContact.isDirty) {
           yield secondaryContact.save();
+          _ember_data.contacts.pushObject(secondaryContact);
         }
+        yield _ember_data.save();
       }
       yield person.save();
-
       this.router.transitionTo('people.person.personal-information', person.id);
     }
   }

--- a/app/routes/people/person/personal-information.js
+++ b/app/routes/people/person/personal-information.js
@@ -48,6 +48,7 @@ export default class PeoplePersonPersonalInformationRoute extends Route {
       const primaryContact = findPrimaryContact(mContacts);
       const secondaryContact = findSecondaryContact(mContacts);
       positions.push({
+        _ember_data: mandatory,
         title: `${role.label}, ${administrativeUnit.name}`,
         role: role.label,
         type: 'mandatory',
@@ -71,6 +72,7 @@ export default class PeoplePersonPersonalInformationRoute extends Route {
       const primaryContact = findPrimaryContact(mContacts);
       const secondaryContact = findSecondaryContact(mContacts);
       positions.push({
+        _ember_data: minister,
         title: `${role.label}, ${administrativeUnit.name}`,
         role: role.label,
         type: 'minister',

--- a/app/routes/people/person/personal-information.js
+++ b/app/routes/people/person/personal-information.js
@@ -48,7 +48,7 @@ export default class PeoplePersonPersonalInformationRoute extends Route {
       const primaryContact = findPrimaryContact(mContacts);
       const secondaryContact = findSecondaryContact(mContacts);
       positions.push({
-        _ember_data: mandatory,
+        _position: mandatory,
         title: `${role.label}, ${administrativeUnit.name}`,
         role: role.label,
         type: 'mandatory',
@@ -72,7 +72,7 @@ export default class PeoplePersonPersonalInformationRoute extends Route {
       const primaryContact = findPrimaryContact(mContacts);
       const secondaryContact = findSecondaryContact(mContacts);
       positions.push({
-        _ember_data: minister,
+        _position: minister,
         title: `${role.label}, ${administrativeUnit.name}`,
         role: role.label,
         type: 'minister',

--- a/app/routes/people/person/personal-information.js
+++ b/app/routes/people/person/personal-information.js
@@ -48,7 +48,7 @@ export default class PeoplePersonPersonalInformationRoute extends Route {
       const primaryContact = findPrimaryContact(mContacts);
       const secondaryContact = findSecondaryContact(mContacts);
       positions.push({
-        _position: mandatory,
+        position: mandatory,
         title: `${role.label}, ${administrativeUnit.name}`,
         role: role.label,
         type: 'mandatory',
@@ -72,7 +72,7 @@ export default class PeoplePersonPersonalInformationRoute extends Route {
       const primaryContact = findPrimaryContact(mContacts);
       const secondaryContact = findSecondaryContact(mContacts);
       positions.push({
-        _position: minister,
+        position: minister,
         title: `${role.label}, ${administrativeUnit.name}`,
         role: role.label,
         type: 'minister',

--- a/app/routes/people/person/personal-information/edit.js
+++ b/app/routes/people/person/personal-information/edit.js
@@ -25,16 +25,15 @@ export default class PeoplePersonPersonalInformationEditRoute extends Route {
     );
     const contacts = [];
     for (let position of positions) {
-      let { primaryContact, secondaryContact, _ember_data } = position;
-      let mContacts = await _ember_data.contacts;
+      let { primaryContact, secondaryContact, _position } = position;
       if (!primaryContact) {
         primaryContact = createPrimaryContact(this.store);
         primaryContact.contactAddress = this.store.createRecord('address');
-        mContacts.toArray().push(primaryContact);
+        _position.contacts.pushObject(primaryContact);
       }
       if (!secondaryContact) {
         secondaryContact = createSecondaryContact(this.store);
-        mContacts.toArray().push(secondaryContact);
+        _position.contacts.pushObject(secondaryContact);
       }
       let address = await primaryContact.contactAddress;
       if (!address) {
@@ -42,7 +41,7 @@ export default class PeoplePersonPersonalInformationEditRoute extends Route {
         primaryContact.contactAddress = address;
       }
       let contact = {
-        _ember_data,
+        _position,
         title: position.title,
         primaryContact: createValidatedChangeset(
           primaryContact,

--- a/app/routes/people/person/personal-information/edit.js
+++ b/app/routes/people/person/personal-information/edit.js
@@ -24,16 +24,15 @@ export default class PeoplePersonPersonalInformationEditRoute extends Route {
       'people.person.personal-information'
     );
     const contacts = [];
-    for (let position of positions) {
-      let { primaryContact, secondaryContact, _position } = position;
+    for (let computedPosition of positions) {
+      let { primaryContact, secondaryContact, position } = computedPosition;
       if (!primaryContact) {
         primaryContact = createPrimaryContact(this.store);
-        primaryContact.contactAddress = this.store.createRecord('address');
-        _position.contacts.pushObject(primaryContact);
+        position.contacts.pushObject(primaryContact);
       }
       if (!secondaryContact) {
         secondaryContact = createSecondaryContact(this.store);
-        _position.contacts.pushObject(secondaryContact);
+        position.contacts.pushObject(secondaryContact);
       }
       let address = await primaryContact.contactAddress;
       if (!address) {
@@ -41,7 +40,7 @@ export default class PeoplePersonPersonalInformationEditRoute extends Route {
         primaryContact.contactAddress = address;
       }
       let contact = {
-        _position,
+        position,
         title: position.title,
         primaryContact: createValidatedChangeset(
           primaryContact,


### PR DESCRIPTION
For some position, when you try to edit them, you get an error (e.g => https://dev.organisaties.abb.lblod.info/personen/19a4d659d73809129467ac1c39e7fd02/contactgegevens )
This PR is an attempt to fix it. As we mix two kinds of resources (mandates, ministers), I had to work around a little bit.