### PR TITLE
Add searchField to power select

### DIFF
--- a/app/components/change-event-type-select.hbs
+++ b/app/components/change-event-type-select.hbs
@@ -1,6 +1,7 @@
 <div class={{if @error "ember-power-select--error"}}>
   <PowerSelect
     @loadingMessage="Aan het laden..."
+    @searchField='label'
     @options={{this.loadChangeEventTypesTask.last}}
     @selected={{@selected}}
     @onChange={{@onChange}}


### PR DESCRIPTION
Even if we don't allow the search, we have to define this property otherwise when power select is open and we type something an error occurs.