### PR TITLE
Handle special characters in search

### DIFF
--- a/app/routes/administrative-units/index.js
+++ b/app/routes/administrative-units/index.js
@@ -42,7 +42,10 @@ export default class AdministrativeUnitsIndexRoute extends Route {
 
     if (params.name) {
       let filterType = 'phrase';
-      let name = params.name.trim().toLowerCase();
+      let name = params.name
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]/gi, ' ');
       if (name.split(' ').length === 1) {
         filterType = 'prefix';
       }


### PR DESCRIPTION
This fixes OP-1222's comment from Zelim.

I tested directly with dev data with `ember serve --proxy=https://dev.organisaties.abb.lblod.info`

- [x] Kerkfabriek St.-Philippus van Schoten
- [x] philipp
- [x] Kerkfabriek St.-Philippus
- [x] St.-Philippus
- [x] Philippus
- [x] O.-L.-Vrouw
- [x] Vrouw
