### PR TITLE
fix: show expected enddate

### DIFF
--- a/app/templates/organizations/organization/core-data/index.hbs
+++ b/app/templates/organizations/organization/core-data/index.hbs
@@ -141,22 +141,21 @@
                 </Item>
               {{/if}}
               {{#if
-                (and
                   (or
                     @model.organization.isIgs
                     @model.organization.isOcmwAssociation
                     @model.organization.isPevaMunicipality
                     @model.organization.isPevaProvince
                   )
-                  @model.region.label
-                )
               }}
-                <Item>
-                  <:label>Regio</:label>
-                  <:content>
-                    {{@model.region.label}}
-                  </:content>
-                </Item>
+                {{#if @model.region.label}}
+                  <Item>
+                    <:label>Regio</:label>
+                    <:content>
+                      {{@model.region.label}}
+                    </:content>
+                  </Item>
+                {{/if}}
                 {{#if @model.organization.expectedEndDate}}
                   <Item>
                     <:label>Geplande einddatum</:label>


### PR DESCRIPTION
Show the expected enddate for isg's

## Issue
The expected enddate wasn't showing because of a strict `and` check for region's. So moved the region if into it's own. 

## How to test
1. Create one of the following:
-Dienstverlenende vereniging
- Projectvereniging
- Opdrachthoudende vereniging
- Opdrachthoudende vereniging met private deelname

2. Fill in the expected enddate, and click create.
3. Verify the expected enddate is now showing up 


## Related tickets
- OP-3367