### PR TITLE
fix: determine filters on organisations page based on user's role

### DIFF
--- a/app/controllers/organizations/index.js
+++ b/app/controllers/organizations/index.js
@@ -2,10 +2,11 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { CLASSIFICATION } from 'frontend-organization-portal/models/administrative-unit-classification-code';
 
 export default class OrganizationsIndexController extends Controller {
   @service router;
+  @service currentSession;
+
   queryParams = [
     'page',
     'size',
@@ -62,19 +63,6 @@ export default class OrganizationsIndexController extends Controller {
 
   get hasErrored() {
     return this.model.loadOrganizationsTaskInstance.isError;
-  }
-
-  get modelHasOnlyWorshipOrganizations() {
-    if (this.organizations && this.organizations.length) {
-      return !this.organizations.slice().some((org) => {
-        return (
-          org.classification_id !== CLASSIFICATION.WORSHIP_SERVICE.id &&
-          org.classification_id !== CLASSIFICATION.CENTRAL_WORSHIP_SERVICE.id &&
-          org.classification_id !== CLASSIFICATION.REPRESENTATIVE_BODY.id
-        );
-      });
-    }
-    return false;
   }
 
   @action

--- a/app/templates/organizations/index.hbs
+++ b/app/templates/organizations/index.hbs
@@ -42,7 +42,7 @@
               @id="filter-province"
             />
           </div>
-          {{#unless this.modelHasOnlyWorshipOrganizations}}
+          {{#if this.currentSession.hasUnitRole}}
             <div class="au-o-grid__item au-u-1-2@small au-u-1-1@medium">
               <AuLabel for="organization-type">Type organisatie</AuLabel>
               <OrganizationTypeMultipleSelect
@@ -53,7 +53,7 @@
                 @id="organization-type"
               />
             </div>
-          {{/unless}}
+          {{/if}}
           <div class="au-o-grid__item au-u-1-2@small au-u-1-1@medium">
             <AuLabel for="classification">Type</AuLabel>
             <ClassificationMultipleSelect
@@ -65,7 +65,7 @@
               @id="classification"
             />
           </div>
-          {{#if this.modelHasOnlyWorshipOrganizations}}
+          {{#if this.currentSession.hasWorshipRole}}
             <div class="au-o-grid__item au-u-1-2@small au-u-1-1@medium">
               <AuLabel for="recognized-worship-types">Soort eredienst</AuLabel>
               <RecognizedWorshipTypeSelect
@@ -137,7 +137,7 @@
             @currentSorting={{this.sort}}
             @label="Type"
           />
-          {{#if this.modelHasOnlyWorshipOrganizations}}
+          {{#if this.currentSession.hasWorshipRole}}
             <AuDataTableThSortable
               @field="recognized_worship_type_name"
               @currentSorting={{this.sort}}
@@ -188,7 +188,7 @@
               </AuLink>
             </td>
             <td>{{organization.classification_name}}</td>
-            {{#if this.modelHasOnlyWorshipOrganizations}}
+            {{#if this.currentSession.hasWorshipRole}}
               <td>{{organization.recognized_worship_type_name}}</td>
             {{/if}}
             <td>{{organization.province}}</td>


### PR DESCRIPTION
Previously the shown filters were based on whether the results in the table
contained worship organisations or not. This resulted in undesired behaviour
when there were no resulting organisations, with the shown filters falling back
to the non-worship ones.

This PR changes that behaviour to determine the shown filters based on the role
of the authenticated user. This results in consistently showing the correct
filters as a user's role remains the same within a single session.

## How to reproduce the initial bug
1. Log in as a worship user to OP
2. Navigate to the organisations overview page
3. Take note of the available filters on the left-hand side, especially those
   labelled *Type* and *Soort eredienst*.
3. Fill in one or more filters in the sidebar such that there are no resulting
   organisations. For example,
   - enter a bogus name in the *Naam* filter; or
   - select a municipality without worship organisations, such as *Aalter (voor
     fusie)*, in the *Gemeente* filter
4. A new *Type organisatie* filter should appear above the *Type* filter and the
   *Soort eredienst* filter should have disappeared.

## Related ticket
- OP-3520