### PR TITLE
refactor: simplify condition to display classification label

### DIFF
--- a/app/components/organization-select.hbs
+++ b/app/components/organization-select.hbs
@@ -21,21 +21,8 @@
     {{else}}
       {{organization.abbName}}
     {{/if}}
-    {{#if
-      (and
-        (not
-          (or
-            (eq
-              organization.classification.label
-              "Centraal bestuur van de eredienst"
-            )
-            (eq organization.classification.label "Bestuur van de eredienst")
-          )
-        )
-        organization.classification
-      )
-    }}
+    {{#unless organization.isWorshipAdministrativeUnit}}
       ({{organization.classification.label}})
-    {{/if}}
+    {{/unless}}
   </PowerSelect>
 </div>


### PR DESCRIPTION
A small simplification of some code that caught my eye reviewing another PR:
- Do not explicitly check whether an organisation has a classification, all
  organisations in OP have one.
- Use the appropriate model function to check whether an organisation is a
  worship administrative unit, instead of comparing classification labels.