### PR TITLE
feat: warn users when they relate an organisation to a non-active one

### DIFF
--- a/app/components/central-worship-select.js
+++ b/app/components/central-worship-select.js
@@ -17,6 +17,7 @@ export default class CentralWorshipSelectComponent extends Component {
   *loadCentralWorshipServicesTask(searchParams = '') {
     const query = {
       sort: 'name',
+      include: 'organization-status',
       filter: {
         'organization-status': {
           id: this.args.limitToActiveOrganizations

--- a/app/components/confirm-relation-with-inactive-organization-modal.hbs
+++ b/app/components/confirm-relation-with-inactive-organization-modal.hbs
@@ -1,3 +1,4 @@
+{{! TODO: This model should be renamed from "inactive" to "non-active". Or it should be merged with the other confirmation modal into a single general confirmation modal.}}
 <AuModal @modalOpen={{true}} @closeModal={{@onCancel}}>
   <:title>Bevestig</:title>
   <:body>Opgelet, je hebt een niet actieve organisatie geselecteerd. Ben je

--- a/app/components/confirm-relation-with-inactive-organization-modal.hbs
+++ b/app/components/confirm-relation-with-inactive-organization-modal.hbs
@@ -4,13 +4,16 @@
     zeker dat je deze relatie wenst toe te voegen?
   </:body>
   <:footer>
-    <AuButtonGroup>
-      <AuButton @alert={{true}} {{on "click" @onConfirm}}>Ja</AuButton>
-      <AuButton
-        @icon="bin"
-        @iconAlignment="left"
-        {{on "click" @onCancel}}
-      >Nee</AuButton>
-    </AuButtonGroup>
+    <AuToolbar @reverse={{true}} as |Group|>
+      <Group>
+        <AuButton
+          @skin="secondary"
+          @icon="bin"
+          @iconAlignment="left"
+          {{on "click" @onCancel}}
+        >Nee</AuButton>
+        <AuButton {{on "click" @onConfirm}}>Ja</AuButton>
+      </Group>
+    </AuToolbar>
   </:footer>
 </AuModal>{{yield}}

--- a/app/components/municipality-select.js
+++ b/app/components/municipality-select.js
@@ -30,6 +30,7 @@ export default class MunicipalitySelectComponent extends Component {
         },
       },
       sort: 'name',
+      include: 'organization-status',
       page: {
         size: 400,
       },

--- a/app/components/organization-multiple-select.js
+++ b/app/components/organization-multiple-select.js
@@ -12,6 +12,7 @@ export default class OrganizationMultipleSelectComponent extends Component {
 
     const query = {
       sort: 'name',
+      include: 'organization-status',
     };
 
     let classificationCodes = this.args.classificationCodes;

--- a/app/components/related-organizations-edit-table.hbs
+++ b/app/components/related-organizations-edit-table.hbs
@@ -63,8 +63,9 @@
                 @selected={{membership.organization}}
                 @error={{errorMessage}}
                 @onChange={{fn (mut membership.organization)}}
-                @classificationCodes={{@model.organization.getClassificationCodesForMembership membership}}
-                @limitToActiveOrganizations={{true}}
+                @classificationCodes={{@model.organization.getClassificationCodesForMembership
+                  membership
+                }}
               />
               {{#if errorMessage}}
                 <AuHelpText @error={{true}}>{{errorMessage}}</AuHelpText>
@@ -77,8 +78,9 @@
                 @selected={{membership.member}}
                 @onChange={{fn (mut membership.member)}}
                 @error={{errorMessage}}
-                @classificationCodes={{@model.organization.getClassificationCodesForMembership membership}}
-                @limitToActiveOrganizations={{true}}
+                @classificationCodes={{@model.organization.getClassificationCodesForMembership
+                  membership
+                }}
               />
               {{#if errorMessage}}
                 <AuHelpText @error={{true}}>{{errorMessage}}</AuHelpText>

--- a/app/components/related-organizations-edit-table.hbs
+++ b/app/components/related-organizations-edit-table.hbs
@@ -62,7 +62,7 @@
                 @disabled={{not (and membership.role membership.isNew)}}
                 @selected={{membership.organization}}
                 @error={{errorMessage}}
-                @onChange={{fn (mut membership.organization)}}
+                @onChange={{fn @setOtherRelatedOrganization membership}}
                 @classificationCodes={{@model.organization.getClassificationCodesForMembership
                   membership
                 }}
@@ -76,7 +76,7 @@
               <OrganizationSelect
                 @disabled={{not (and membership.role membership.isNew)}}
                 @selected={{membership.member}}
-                @onChange={{fn (mut membership.member)}}
+                @onChange={{fn @setOtherRelatedOrganization membership}}
                 @error={{errorMessage}}
                 @classificationCodes={{@model.organization.getClassificationCodesForMembership
                   membership

--- a/app/components/representative-body-select.js
+++ b/app/components/representative-body-select.js
@@ -17,6 +17,7 @@ export default class RepresentativeBodySelectComponent extends Component {
   *loadRepresentativeBodiesTask() {
     const representativeBodies = yield this.store.findAll(
       'representative-body',
+      { include: 'organization-status' },
     );
 
     const filteredRepresentativeBodies = representativeBodies.filter((body) => {

--- a/app/components/worship-service-multiple-select.js
+++ b/app/components/worship-service-multiple-select.js
@@ -12,6 +12,7 @@ export default class WorshipServiceSelectComponent extends Component {
 
     const query = {
       sort: 'name',
+      include: 'organization-status',
       filter: {
         'organization-status': {
           id: this.args.limitToActiveOrganizations

--- a/app/controllers/organizations/organization/related-organizations/edit.js
+++ b/app/controllers/organizations/organization/related-organizations/edit.js
@@ -21,6 +21,9 @@ export default class OrganizationsOrganizationRelatedOrganizationsEditController
 
   @tracked founderToRemove;
 
+  @tracked nonActiveMembership;
+  @tracked nonActiveRelatedOrganization;
+
   get hasValidationErrors() {
     return this.memberships.some((membership) => membership.error);
   }
@@ -76,6 +79,41 @@ export default class OrganizationsOrganizationRelatedOrganizationsEditController
       membership.deleteRecord();
     }
     this.founderToRemove = false;
+  }
+
+  @action
+  setRelatedOrganizationMembership(membership, organization) {
+    if (organization.isActive) {
+      this.#setOtherMembershipResource(membership, organization);
+    } else {
+      this.nonActiveMembership = membership;
+      this.nonActiveRelatedOrganization = organization;
+    }
+  }
+
+  @action
+  confirmNonActiveRelatedOrganization() {
+    this.#setOtherMembershipResource(
+      this.nonActiveMembership,
+      this.nonActiveRelatedOrganization,
+    );
+    this.nonActiveMembership = undefined;
+    this.nonActiveRelatedOrganization = undefined;
+  }
+
+  @action
+  cancelNonActiveRelatedOrganization() {
+    this.#setOtherMembershipResource(this.nonActiveMembership, undefined);
+    this.nonActiveMembership = undefined;
+    this.nonActiveRelatedOrganization = undefined;
+  }
+
+  #setOtherMembershipResource(membership, organization) {
+    if (membership.member.id === this.model.organization.id) {
+      membership.organization = organization;
+    } else {
+      membership.member = organization;
+    }
   }
 
   @action
@@ -180,5 +218,7 @@ export default class OrganizationsOrganizationRelatedOrganizationsEditController
     this.memberships = null;
     this.selectedRoleLabel = null;
     this.founderToRemove = null;
+    this.nonActiveMembership = null;
+    this.nonActiveRelatedOrganization = null;
   }
 }

--- a/app/templates/organizations/new.hbs
+++ b/app/templates/organizations/new.hbs
@@ -312,7 +312,6 @@
                       <WorshipServiceMultipleSelect
                         @selected={{this.worshipServices}}
                         @onChange={{fn (mut this.worshipServices)}}
-                        @limitToActiveOrganizations={{true}}
                         id="related-worship-services"
                       />
                     </:content>
@@ -328,7 +327,6 @@
                       <CentralWorshipSelect
                         @selected={{this.centralWorshipService}}
                         @onChange={{fn (mut this.centralWorshipService)}}
-                        @limitToActiveOrganizations={{true}}
                         @error={{hasError}}
                         @id="related-central-worship-service"
                       />
@@ -342,10 +340,6 @@
                 >
                   <:label>Representatief orgaan</:label>
                   <:content as |hasError|>
-                    {{! NOTE: No need to explicitly filter for active
-                      organizations. There is currently only one inactive
-                      representative body and that is blacklisted in the
-                      component. }}
                     <RepresentativeBodySelect
                       @selected={{this.representativeBody}}
                       @onChange={{fn (mut this.representativeBody)}}
@@ -370,7 +364,12 @@
                 }}
                   <Item
                     @labelFor="related-gemeente"
-                    @required={{or this.currentOrganizationModel.isAgb this.currentOrganizationModel.isIgs this.currentOrganizationModel.isPoliceZone this.currentOrganizationModel.isAssistanceZone}}
+                    @required={{or
+                      this.currentOrganizationModel.isAgb
+                      this.currentOrganizationModel.isIgs
+                      this.currentOrganizationModel.isPoliceZone
+                      this.currentOrganizationModel.isAssistanceZone
+                    }}
                     @errorMessage={{this.municipalityError}}
                   >
                     <:label>Gemeente</:label>
@@ -379,7 +378,6 @@
                         @selected={{this.municipality}}
                         @onChange={{this.setMunicipality}}
                         @error={{hasError}}
-                        @limitToActiveOrganizations={{true}}
                         @id="related-gemeente"
                       />
                     </:content>
@@ -411,7 +409,6 @@
                           @selected={{this.participants}}
                           @onChange={{fn (mut this.participants)}}
                           @classificationCodes={{this.currentOrganizationModel.participantClassifications}}
-                          @limitToActiveOrganizations={{true}}
                           @error={{hasError}}
                           @id="participants-igs"
                         />
@@ -437,7 +434,6 @@
                           @selected={{this.founders}}
                           @onChange={{this.addFounders}}
                           @classificationCodes={{this.currentOrganizationModel.founderClassifications}}
-                          @limitToActiveOrganizations={{true}}
                           @error={{hasError}}
                           @id="founders-ocmw-association-peva"
                         />
@@ -451,7 +447,6 @@
                           @selected={{this.participants}}
                           @onChange={{fn (mut this.participants)}}
                           @classificationCodes={{this.currentOrganizationModel.participantClassifications}}
-                          @limitToActiveOrganizations={{true}}
                           @error={{hasError}}
                           @id="participants-ocmw-association-peva"
                         />
@@ -466,8 +461,6 @@
                     >
                       <:label>Provincie</:label>
                       <:content as |hasError|>
-                        {{! NOTE: No need to explicitly filter for active
-                          provinces as they are all active. }}
                         <ProvinceOrganizationSelect
                           @selected={{this.province}}
                           @selectedMunicipality={{this.municipality}}
@@ -491,7 +484,6 @@
                           @selectedProvince={{this.province}}
                           @allowClear={{true}}
                           @onChange={{this.setMunicipality}}
-                          @limitToActiveOrganizations={{true}}
                           @error={{hasError}}
                           @id="related-municipality"
                         />

--- a/app/templates/organizations/new.hbs
+++ b/app/templates/organizations/new.hbs
@@ -311,7 +311,7 @@
                     <:content>
                       <WorshipServiceMultipleSelect
                         @selected={{this.worshipServices}}
-                        @onChange={{fn (mut this.worshipServices)}}
+                        @onChange={{this.addWorshipServices}}
                         id="related-worship-services"
                       />
                     </:content>
@@ -326,7 +326,7 @@
                     <:content as |hasError|>
                       <CentralWorshipSelect
                         @selected={{this.centralWorshipService}}
-                        @onChange={{fn (mut this.centralWorshipService)}}
+                        @onChange={{this.addCentralWorshipService}}
                         @error={{hasError}}
                         @id="related-central-worship-service"
                       />
@@ -342,7 +342,7 @@
                   <:content as |hasError|>
                     <RepresentativeBodySelect
                       @selected={{this.representativeBody}}
-                      @onChange={{fn (mut this.representativeBody)}}
+                      @onChange={{this.addRepresentativeBody}}
                       @error={{hasError}}
                       @id="related-representative-body"
                     />
@@ -407,7 +407,7 @@
                       <:content as |hasError|>
                         <OrganizationMultipleSelect
                           @selected={{this.participants}}
-                          @onChange={{fn (mut this.participants)}}
+                          @onChange={{this.addParticipants}}
                           @classificationCodes={{this.currentOrganizationModel.participantClassifications}}
                           @error={{hasError}}
                           @id="participants-igs"
@@ -445,7 +445,7 @@
                       <:content as |hasError|>
                         <OrganizationMultipleSelect
                           @selected={{this.participants}}
-                          @onChange={{fn (mut this.participants)}}
+                          @onChange={{this.addParticipants}}
                           @classificationCodes={{this.currentOrganizationModel.participantClassifications}}
                           @error={{hasError}}
                           @id="participants-ocmw-association-peva"
@@ -504,3 +504,10 @@
     {{/if}}
   </form>
 </div>
+
+{{#if this.isRelatedNonActiveOrganization}}
+  <ConfirmRelationWithInactiveOrganizationModal
+    @onConfirm={{this.confirmRelateNonActiveOrganization}}
+    @onCancel={{this.cancelRelateNonActiveOrganization}}
+  />
+{{/if}}

--- a/app/templates/organizations/organization/related-organizations/edit.hbs
+++ b/app/templates/organizations/organization/related-organizations/edit.hbs
@@ -50,9 +50,17 @@
           @showConfirmMembershipRemoval={{this.founderToRemove}}
           @confirmMembershipRemoval={{this.reallyRemoveMembership}}
           @cancelMembershipRemoval={{this.cancelMembershipRemoval}}
+          @setOtherRelatedOrganization={{this.setRelatedOrganizationMembership}}
           id="edit-related-organizations"
         />
       </div>
     </form>
   </div>
 </div>
+
+{{#if this.nonActiveRelatedOrganization}}
+  <ConfirmRelationWithInactiveOrganizationModal
+    @onConfirm={{this.confirmNonActiveRelatedOrganization}}
+    @onCancel={{this.cancelNonActiveRelatedOrganization}}
+  />
+{{/if}}


### PR DESCRIPTION
When a user tries to relate an organisation to another, non-active organisation
show a modal warning them about this. This modal requires the user to explicitly
confirm or cancel their choice.

## How to test
For existing organisations:
1. Launch an OP frontend with this branch
2. Log in as editor (either worship or non-worship)
4. Select an organisation
5. Navigate to the related organisations (*nl. Gerelateerde organisaties*) tab
   and click the edit button in the top right corner
6. Play around with adding relations with active and non-active organisations
   to see the modal appears when expected. Also try saving and cancelling
   changes to ensure no errors pop up in this flow.

For creating new organisations:
1. Launch an OP frontend with this branch
2. Log in as editor (either worship or non-worship)
3. On the organisations page click the "+ Nieuw" button in the top-right corner
   to create a new organisation.
4. Play around with creating different types of organisations. The relevant
   fields are located in the bottom part of the form in the "Gerelateerde
   organisaties" section. The exact contents will differ based on the selected
   "Type organisatie".

## Notes
- In this context "non-active" means any organisations with a status other than
  active (*nl. Actief*). Currently this covers organisations that are inactive
  (*nl. Niet Actief*) or in formation (*nl. In oprichting*).
- When the membership relations were introduced the required functionality was
  to only allow relations between active organisations. As part of this PR this
  rule is relaxed so users can select non-active organisations.

## Related tickets
- OP-3468