### PR TITLE
fix: correctly format feature flag table

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Or in template files by using the `is-feature-enabled` helper:
 
 ```handlebars
 {{#if (is-feature-enabled "new-feature")}}
-  <p>New feature is enabled!</p>
+  <p>New feature is enabled!</p>a
 {{else}}
   <p>New feature is disabled!</p>
 {{/if}}
@@ -114,7 +114,8 @@ Or in template files by using the `is-feature-enabled` helper:
 
 ### List of feature flags
 
-| Name | Description |
+| Name              | Description                        |
+|-------------------|------------------------------------|
 | edit-contact-data | Enable the edition of contact site |
 
 ## Releasing a new version


### PR DESCRIPTION
Small detail that caught my eye. The table for the available feature flags did not properly render anymore. Re-adding the horizontal line fixes this.