### PR TITLE
fix: correctly retrieve resulting organisations for new change event

### DIFF
--- a/app/controllers/organizations/organization/change-events/new.js
+++ b/app/controllers/organizations/organization/change-events/new.js
@@ -180,9 +180,10 @@ export default class OrganizationsOrganizationChangeEventsNewController extends 
             if (currentOrganization.isCentralWorshipService) {
               resultingStatusId = ORGANIZATION_STATUS.INACTIVE;
             } else {
-              resultingStatusId = changeEvent.resultingOrganizations.includes(
-                organization,
-              )
+              const resultingOrganizations = changeEvent
+                .hasMany('resultingOrganizations')
+                .value();
+              resultingStatusId = resultingOrganizations.includes(organization)
                 ? ORGANIZATION_STATUS.ACTIVE
                 : ORGANIZATION_STATUS.INACTIVE;
             }
@@ -208,7 +209,10 @@ export default class OrganizationsOrganizationChangeEventsNewController extends 
             // Central worship services should always select a *new*
             // organization as the resulting organization, so we also create a
             // change event result for that organization
-            for (let organization of changeEvent.resultingOrganizations.slice()) {
+            const resultingOrganizations = changeEvent
+              .hasMany('resultingOrganizations')
+              .value();
+            for (let organization of resultingOrganizations) {
               createChangeEventResultsPromises.push(
                 createChangeEventResult({
                   resultingStatusId: ORGANIZATION_STATUS.ACTIVE,

--- a/app/controllers/organizations/organization/change-events/new.js
+++ b/app/controllers/organizations/organization/change-events/new.js
@@ -180,12 +180,12 @@ export default class OrganizationsOrganizationChangeEventsNewController extends 
             if (currentOrganization.isCentralWorshipService) {
               resultingStatusId = ORGANIZATION_STATUS.INACTIVE;
             } else {
-              const resultingOrganizations = changeEvent
-                .hasMany('resultingOrganizations')
-                .value();
-              resultingStatusId = resultingOrganizations.includes(organization)
-                ? ORGANIZATION_STATUS.ACTIVE
-                : ORGANIZATION_STATUS.INACTIVE;
+              resultingStatusId =
+                (yield changeEvent.resultingOrganizations).includes(
+                  organization,
+                )
+                  ? ORGANIZATION_STATUS.ACTIVE
+                  : ORGANIZATION_STATUS.INACTIVE;
             }
           } else {
             resultingStatusId =
@@ -209,10 +209,7 @@ export default class OrganizationsOrganizationChangeEventsNewController extends 
             // Central worship services should always select a *new*
             // organization as the resulting organization, so we also create a
             // change event result for that organization
-            const resultingOrganizations = changeEvent
-              .hasMany('resultingOrganizations')
-              .value();
-            for (let organization of resultingOrganizations) {
+            for (let organization of (yield changeEvent.resultingOrganizations).slice()) {
               createChangeEventResultsPromises.push(
                 createChangeEventResult({
                   resultingStatusId: ORGANIZATION_STATUS.ACTIVE,


### PR DESCRIPTION
Use the `hasMany` function to correctly resolve the async
`resultingOrganizations` relationship before accessing its elements. This
resolves a bug where creating a new merger change event results in errors being
thrown.

## How to reproduce the bugs
1. Log in as worship editor user
2. Select a (central) worship service from the organisations overview, any
   should do
3. Navigate to the change events tab (*nl. Veranderingsgebeurtenissen*)
4. Create a new change event by clicking the "+ Nieuw" button in the top-right
   corner
5. As change event type select a merger (*nl. Samenvoeging*)
6. Fill in at least the required fields
7. Try to save the change event by clicking the save button in the top-right
   corner. A `TypeError` should appear in the developer console.

For non-worship organisations the same bug can be triggered:
1. Log in as editor user
2. Select an IGS organisation (Projectvereniging, Dienstverlenende vereniging,
   Opdrachthoudende vereniging, or Opdrachthoudende vereniging met private
   deelname), any should do
3. Navigate to the change events tab (*nl. Veranderingsgebeurtenissen*)
4. Create a new change event by clicking the "+ Nieuw" button in the top-right
   corner
5. As change event type select a merger (*nl. Fusie*)
6. Fill in at least the required fields
7. Try to save the change event by clicking the save button in the top-right
   corner. A `TypeError` should appear in the developer console.

## Related ticket
- OP-3353