### PR TITLE
feat: consult and edit an administrative unit's scope of operation

### DIFF
--- a/app/components/location-multiple-select.hbs
+++ b/app/components/location-multiple-select.hbs
@@ -1,0 +1,19 @@
+<div class={{if @error "ember-power-select--error"}}>
+  <PowerSelectMultiple
+    @loadingMessage="Aan het laden..."
+    @noMatchesMessage="Geen resultaten"
+    @searchMessage="Typ om te zoeken"
+    @disabled={{@disabled}}
+    @allowClear={{true}}
+    @searchEnabled={{true}}
+    @searchField="label"
+    @search={{perform this.loadLocationsMultipleTask}}
+    @closeOnSelect={{false}}
+    @selected={{@selected}}
+    @onChange={{@onChange}}
+    @triggerId={{@id}}
+    as |location|
+  >
+    {{location.label}}
+  </PowerSelectMultiple>
+</div>

--- a/app/components/location-multiple-select.js
+++ b/app/components/location-multiple-select.js
@@ -1,0 +1,45 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { restartableTask } from 'ember-concurrency';
+
+// TODO: open dropdown with all results on focus/open
+// TODO: clear input after selection
+export default class LocationMultipleSelectComponent extends Component {
+  @service store;
+
+  @restartableTask
+  *loadLocationsMultipleTask(searchParams = '') {
+    const provinces = this.args.provinceLocations;
+
+    const query = {
+      filter: { level: 'Gemeente' },
+      sort: 'label',
+      include: 'located-within',
+      // NOTE (21/05/2025): Make sure to load all municipality locations
+      page: { size: 400 },
+    };
+
+    if (searchParams.trim() !== '') {
+      query['filter[label]'] = searchParams;
+    }
+
+    const municipalities = yield this.store.query('location', query);
+
+    return this.extractProvinceGroups(provinces, municipalities);
+  }
+
+  extractProvinceGroups(provinces, municipalities) {
+    return provinces
+      .map((province) => this.createGroupForProvince(province, municipalities))
+      .filter((group) => group.options.length > 0);
+  }
+
+  createGroupForProvince(province, municipalities) {
+    return {
+      groupName: province.label,
+      options: municipalities.filter((municipality) =>
+        municipality.isLocatedWithin(province),
+      ),
+    };
+  }
+}

--- a/app/controllers/organizations/new.js
+++ b/app/controllers/organizations/new.js
@@ -14,6 +14,7 @@ export default class OrganizationsNewController extends Controller {
   @service router;
   @service store;
   @service features;
+  @service scopeOfOperation;
 
   @tracked currentOrganizationModel;
 
@@ -31,6 +32,8 @@ export default class OrganizationsNewController extends Controller {
 
   @tracked relatedNonActiveOrganization;
   @tracked setRelatedOrganizationFunction;
+
+  @tracked locations;
 
   get hasValidationErrors() {
     return (
@@ -571,6 +574,11 @@ export default class OrganizationsNewController extends Controller {
       ),
     );
 
+    this.currentOrganizationModel.scope =
+      this.locations?.length > 0
+        ? yield this.scopeOfOperation.getScopeForLocations(...this.locations)
+        : null;
+
     yield Promise.all([
       this.currentOrganizationModel.validate({ creatingNewOrganization: true }),
       identifierKBO.validate(),
@@ -695,5 +703,6 @@ export default class OrganizationsNewController extends Controller {
     this.representativeBody = null;
     this.relatedNonActiveOrganization = null;
     this.setRelatedOrganizationFunction = null;
+    this.locations = null;
   }
 }

--- a/app/controllers/organizations/organization/core-data/edit.js
+++ b/app/controllers/organizations/organization/core-data/edit.js
@@ -59,7 +59,8 @@ export default class OrganizationsOrganizationCoreDataEditController extends Con
 
     // NOTE (05/06/2025): Explicitly set the scope to `undefined` when the user
     // did not select any locations, or removed all originally set
-    // locations. Otherwise the any previously set scope just be kept.
+    // locations. Otherwise, any edits are ignored and the previously set scope
+    // of operation is just silently kept.
     organization.scope =
       this.locationsInScope?.length > 0
         ? yield this.scopeOfOperation.getScopeForLocations(

--- a/app/controllers/organizations/organization/core-data/edit.js
+++ b/app/controllers/organizations/organization/core-data/edit.js
@@ -5,11 +5,15 @@ import { combineFullAddress } from 'frontend-organization-portal/models/address'
 import { action } from '@ember/object';
 import { setEmptyStringsToNull } from 'frontend-organization-portal/utils/empty-string-to-null';
 import isContactEditableOrganization from 'frontend-organization-portal/utils/editable-contact-data';
+import { tracked } from '@glimmer/tracking';
 
 export default class OrganizationsOrganizationCoreDataEditController extends Controller {
   @service router;
   @service store;
   @service features;
+  @service scopeOfOperation;
+
+  @tracked locationsInScope;
 
   get hasValidationErrors() {
     return (
@@ -52,6 +56,16 @@ export default class OrganizationsOrganizationCoreDataEditController extends Con
       structuredIdentifierSharepoint,
       structuredIdentifierKBO,
     } = this.model;
+
+    // NOTE (05/06/2025): Explicitly set the scope to `undefined` when the user
+    // did not select any locations, or removed all originally set
+    // locations. Otherwise the any previously set scope just be kept.
+    organization.scope =
+      this.locationsInScope?.length > 0
+        ? yield this.scopeOfOperation.getScopeForLocations(
+            ...this.locationsInScope,
+          )
+        : undefined;
 
     yield Promise.all([
       organization.validate({ relaxMandatoryFoundingOrganization: true }),
@@ -164,5 +178,6 @@ export default class OrganizationsOrganizationCoreDataEditController extends Con
 
   reset() {
     this.resetUnsavedRecords();
+    this.locationsInScope = [];
   }
 }

--- a/app/models/administrative-unit.js
+++ b/app/models/administrative-unit.js
@@ -168,6 +168,15 @@ export default class AdministrativeUnitModel extends OrganizationModel {
     return true;
   }
 
+  get displayRegion() {
+    return (
+      this.isMunicipality ||
+      this.isIgs ||
+      this.isPevaMunicipality ||
+      this.isPevaProvince
+    );
+  }
+
   get participantClassifications() {
     return allowedParticipationMemberships
       .filter((e) => e.organizations.includes(this.classification.id))

--- a/app/models/administrative-unit.js
+++ b/app/models/administrative-unit.js
@@ -3,6 +3,7 @@ import OrganizationModel from './organization';
 import Joi from 'joi';
 import {
   validateBelongsToOptional,
+  validateBelongsToRequired,
   validateHasManyNotEmptyRequired,
   validateHasManyOptional,
 } from '../validators/schema';
@@ -72,7 +73,7 @@ export default class AdministrativeUnitModel extends OrganizationModel {
       governingBodies: validateHasManyOptional(),
       involvedBoards: validateHasManyOptional(),
       exactMatch: validateBelongsToOptional(),
-      scope: validateBelongsToOptional(),
+      scope: validateBelongsToRequired(REQUIRED_MESSAGE),
       // Notes:
       // - The requested functionality was to *not* validate memberships of
       //   already existing organizations. When creating a new organization a

--- a/app/models/location.js
+++ b/app/models/location.js
@@ -29,4 +29,8 @@ export default class LocationModel extends Model {
     async: true,
   })
   exactMatch;
+
+  isLocatedWithin(location) {
+    return this.hasMany('locatedWithin').ids().includes(location.id);
+  }
 }

--- a/app/models/location.js
+++ b/app/models/location.js
@@ -12,7 +12,7 @@ export default class LocationModel extends Model {
   })
   administrativeUnits;
 
-  @belongsTo('location', {
+  @hasMany('location', {
     inverse: 'locations',
     async: true,
   })

--- a/app/models/registered-organization.js
+++ b/app/models/registered-organization.js
@@ -43,6 +43,10 @@ export default class RegisteredOrganizationModel extends OrganizationModel {
     return this._hasClassificationId(OcmwAssociationCodeList);
   }
 
+  get displayRegion() {
+    return this.isOcmwAssociation;
+  }
+
   get isPrivateOcmwAssociation() {
     return this._hasClassificationId(PrivateOcmwAssociationCodeList);
   }

--- a/app/routes/organizations/new.js
+++ b/app/routes/organizations/new.js
@@ -47,6 +47,11 @@ export default class OrganizationsNewRoute extends Route {
       ].join(','),
     });
 
+    const provinceLocations = await this.store.query('location', {
+      sort: 'label',
+      filter: { level: 'Provincie' },
+    });
+
     return {
       primarySite: this.store.createRecord('site'),
       address: this.store.createRecord('address', {
@@ -59,6 +64,7 @@ export default class OrganizationsNewRoute extends Route {
       identifierSharepoint,
       structuredIdentifierSharepoint,
       roles,
+      provinceLocations,
     };
   }
 

--- a/app/routes/organizations/organization/core-data/edit.js
+++ b/app/routes/organizations/organization/core-data/edit.js
@@ -17,6 +17,9 @@ export default class OrganizationsOrganizationCoreDataEditRoute extends Route {
   @service store;
   @service currentSession;
   @service router;
+  @service scopeOfOperation;
+
+  locationsInScope = [];
 
   beforeModel() {
     if (!this.currentSession.canEdit) {
@@ -112,6 +115,14 @@ export default class OrganizationsOrganizationCoreDataEditRoute extends Route {
       }
     }
 
+    const provinceLocations = await this.store.query('location', {
+      sort: 'label',
+      filter: { level: 'Provincie' },
+    });
+
+    this.locationsInScope =
+      await this.scopeOfOperation.getLocationsInScope(organization);
+
     return {
       organization,
       address,
@@ -126,6 +137,7 @@ export default class OrganizationsOrganizationCoreDataEditRoute extends Route {
       structuredIdentifierNIS,
       structuredIdentifierOVO,
       region,
+      provinceLocations,
     };
   }
 
@@ -157,5 +169,16 @@ export default class OrganizationsOrganizationCoreDataEditRoute extends Route {
 
       return missingIdentifiers;
     }, []);
+  }
+
+  resetController(controller) {
+    super.resetController(...arguments);
+    controller.reset();
+  }
+
+  setupController(controller) {
+    super.setupController(...arguments);
+
+    controller.set('locationsInScope', this.locationsInScope);
   }
 }

--- a/app/routes/organizations/organization/core-data/edit.js
+++ b/app/routes/organizations/organization/core-data/edit.js
@@ -183,11 +183,6 @@ export default class OrganizationsOrganizationCoreDataEditRoute extends Route {
     }, []);
   }
 
-  resetController(controller) {
-    super.resetController(...arguments);
-    controller.reset();
-  }
-
   setupController(controller) {
     super.setupController(...arguments);
 

--- a/app/routes/organizations/organization/core-data/edit.js
+++ b/app/routes/organizations/organization/core-data/edit.js
@@ -89,30 +89,42 @@ export default class OrganizationsOrganizationCoreDataEditRoute extends Route {
     );
     let structuredIdentifierOVO = await identifierOVO.structuredIdentifier;
 
+    // Determine reference region for some classes of organizations
+    // TODO: this is duplicate from the view route
     let region;
-
-    if (
-      organization.isIgs ||
-      organization.isOcmwAssociation ||
-      organization.isPevaProvince ||
-      organization.isPevaMunicipality
-    ) {
-      const address = await primarySite?.address;
-      const municipalityString = address?.municipality;
-      if (municipalityString) {
-        const municipalityUnit = (
-          await this.store.query('organization', {
-            filter: {
-              ':exact:name': municipalityString,
-              classification: {
-                ':id:': CLASSIFICATION.MUNICIPALITY.id,
+    if (organization.displayRegion) {
+      let scope;
+      if (organization.isMunicipality) {
+        scope = await organization.scope;
+      } else if (
+        organization.isIgs ||
+        organization.isOcmwAssociation ||
+        organization.isPevaProvince ||
+        organization.isPevaMunicipality
+      ) {
+        const address = await primarySite?.address;
+        const municipalityString = address?.municipality;
+        if (municipalityString) {
+          const municipalityUnit = (
+            await this.store.query('organization', {
+              filter: {
+                ':exact:name': municipalityString,
+                classification: {
+                  ':id:': CLASSIFICATION.MUNICIPALITY.id,
+                },
               },
-            },
-          })
-        ).at(0);
-        const scope = await municipalityUnit.scope;
-        region = await scope.locatedWithin;
+            })
+          ).at(0);
+          scope = await municipalityUnit.scope;
+        }
       }
+      const containingLocations = await scope.locatedWithin;
+      // NOTE (03/06/2025): This relies on the fact that reference regions do
+      // *not* overlap. In other words, an organisation cannot be located in
+      // multiple reference regions.
+      region = await containingLocations.find(
+        (location) => location.level === 'Referentieregio',
+      );
     }
 
     const provinceLocations = await this.store.query('location', {

--- a/app/routes/organizations/organization/core-data/index.js
+++ b/app/routes/organizations/organization/core-data/index.js
@@ -8,6 +8,7 @@ import { CLASSIFICATION } from 'frontend-organization-portal/models/administrati
 
 export default class OrganizationsOrganizationCoreDataIndexRoute extends Route {
   @service store;
+  @service scopeOfOperation;
 
   async model() {
     let organization = this.modelFor('organizations.organization.core-data');
@@ -63,6 +64,8 @@ export default class OrganizationsOrganizationCoreDataIndexRoute extends Route {
       }
     }
 
+    const scopeLabel = await this.scopeOfOperation.getScopeLabel(organization);
+
     const kboOrganization = await organization.kboOrganization;
     const kboContacts = (await kboOrganization?.contacts) ?? [];
 
@@ -74,6 +77,7 @@ export default class OrganizationsOrganizationCoreDataIndexRoute extends Route {
       primaryContact: findPrimaryContact(contacts),
       secondaryContact: findSecondaryContact(contacts),
       region,
+      scopeLabel,
       kboContact: findPrimaryContact(kboContacts),
     };
   }

--- a/app/services/scope-of-operation.js
+++ b/app/services/scope-of-operation.js
@@ -1,0 +1,36 @@
+import Service, { service } from '@ember/service';
+
+export default class ScopeOfOperationService extends Service {
+  @service store;
+
+  getScopeServiceEndpoint(path, location) {
+    const locationArg = location ? `/${location.id}` : '';
+    return `/scope-of-operation/${path}${locationArg}`;
+  }
+
+  /**
+   * Retrieve the label to be displayed for the provided organization's scope of
+   * of operation. Only administrative units can have a scope of operation
+   * defined.
+   * @param {Organization} organization - The organization for which to retrieve
+   *     the label.
+   * @returns {Promise<string | null>} The appropriate label that should be
+   *     displayed for the organization's scope
+   */
+  async getScopeLabel(organization) {
+    const scope = await organization.scope;
+
+    let label;
+    if (organization.isAdministrativeUnit && scope) {
+      const resp = await fetch(
+        this.getScopeServiceEndpoint('label-for-scope', scope),
+      );
+
+      if (resp.status === 200) {
+        label = await resp.json();
+      }
+    }
+
+    return label;
+  }
+}

--- a/app/services/scope-of-operation.js
+++ b/app/services/scope-of-operation.js
@@ -33,4 +33,73 @@ export default class ScopeOfOperationService extends Service {
 
     return label;
   }
+
+  /**
+   * Retrieve the location resources that are contained within the scope of
+   * operation of the provided organization. The location resources contained
+   * will be of the smallest level used, typically locations of municipality
+   * level.
+   * @param {Organization} organization - The organization for which the
+   *     retrieve its locations.
+   * @returns {Promise<Location[]>} An array containing the locations that are
+   *     within the provided organization's scope of operation.
+   */
+  async getLocationsInScope(organization) {
+    const scope = await organization.scope;
+
+    let locations;
+    if (organization.isAdministrativeUnit && scope) {
+      const resp = await fetch(
+        this.getScopeServiceEndpoint('locations-in-scope', scope),
+      );
+
+      if (resp.status === 200) {
+        const jsonResponse = await resp.json();
+        locations = await this.store.query('location', {
+          filter: {
+            ':id:': jsonResponse.join(','),
+          },
+          sort: 'label',
+        });
+      }
+    }
+    return locations;
+  }
+
+  /**
+   * Retrieve the location resource that exactly contains the provided
+   * locations. This location can be assigned to an organisation as its scope of
+   * operation.
+   * @param {...Location} locations - The locations that should be contained.
+   * @returns {Promise<Location | null>} - The location that exactly matches the
+   *     provided ones, null if no locations were provided.
+   */
+  async getScopeForLocations(...locations) {
+    if (locations.length === 0) {
+      return null;
+    }
+
+    const requestBody = {
+      data: {
+        locations: locations.map((location) => location.id),
+      },
+    };
+
+    const scopeUuid = await fetch(
+      this.getScopeServiceEndpoint('scope-for-locations'),
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/vnd.api+json',
+          'Content-Type': 'application/vnd.api+json',
+        },
+        body: JSON.stringify(requestBody),
+      },
+    );
+
+    const uuid = await scopeUuid.json();
+    const scopeResource = await this.store.findRecord('location', uuid);
+
+    return scopeResource;
+  }
 }

--- a/app/templates/organizations/new.hbs
+++ b/app/templates/organizations/new.hbs
@@ -173,6 +173,25 @@
                 </:content>
               </Item>
             {{/if}}
+            {{#if this.currentOrganizationModel.isAdministrativeUnit}}
+              <Item
+                @labelFor="scope"
+                @required={{true}}
+                @errorMessage={{this.currentOrganizationModel.error.scope.message}}
+              >
+                <:label>Werkingsgebied</:label>
+                <:content>
+                  <LocationMultipleSelect
+                    @selected={{this.locations}}
+                    @onChange={{fn (mut this.locations)}}
+                    @disabled={{false}}
+                    @provinceLocations={{@model.provinceLocations}}
+                    @error={{this.currentOrganizationModel.error.scope}}
+                    @id="locations-select"
+                  />
+                </:content>
+              </Item>
+            {{/if}}
             {{#if this.currentOrganizationModel.isIgs}}
               <Item
                 @labelFor="expectedEndDate"

--- a/app/templates/organizations/organization/core-data/edit.hbs
+++ b/app/templates/organizations/organization/core-data/edit.hbs
@@ -64,7 +64,10 @@
                   <:content as |hasError|>
                     <TrimInput
                       @width="block"
-                      @disabled={{or @model.organization.isMunicipality @model.organization.isProvince}}
+                      @disabled={{or
+                        @model.organization.isMunicipality
+                        @model.organization.isProvince
+                      }}
                       @value={{@model.organization.legalName}}
                       @onUpdate={{this.setNames}}
                       @error={{hasError}}
@@ -180,6 +183,28 @@
                         @value={{@model.region.label}}
                         @disabled="true"
                         id="igs-regio"
+                      />
+                    </:content>
+                  </Item>
+                {{/if}}
+                {{#if @model.organization.isAdministrativeUnit}}
+                  <Item
+                    @labelFor="scope"
+                    @required={{true}}
+                    @errorMessage={{@model.organization.error.scope.message}}
+                  >
+                    <:label>Werkingsgebied</:label>
+                    <:content>
+                      <LocationMultipleSelect
+                        @selected={{this.locationsInScope}}
+                        @onChange={{fn (mut this.locationsInScope)}}
+                        @disabled={{or
+                          @model.organization.isMunicipality
+                          @model.organization.isProvince
+                        }}
+                        @provinceLocations={{@model.provinceLocations}}
+                        @error={{@model.organization.error.scope}}
+                        @id="locations-select"
                       />
                     </:content>
                   </Item>

--- a/app/templates/organizations/organization/core-data/edit.hbs
+++ b/app/templates/organizations/organization/core-data/edit.hbs
@@ -159,30 +159,17 @@
                     </:content>
                   </Item>
                 {{/if}}
-                {{#if @model.organization.isMunicipality}}
-                  <Item @labelFor="regio">
-                    <:label>Regio</:label>
-                    <:content>
-                      {{@model.organization.scope.locatedWithin.label}}
-                    </:content>
-                  </Item>
-                {{/if}}
                 {{#if
-                  (or
-                    @model.organization.isIgs
-                    @model.organization.isOcmwAssociation
-                    @model.organization.isPevaProvince
-                    @model.organization.isPevaMunicipality
-                  )
+                  (and @model.organization.displayRegion @model.region.label)
                 }}
-                  <Item @labelFor="igs-regio">
+                  <Item>
                     <:label>Regio</:label>
                     <:content>
                       <TrimInput
                         @width="block"
                         @value={{@model.region.label}}
                         @disabled="true"
-                        id="igs-regio"
+                        id="region"
                       />
                     </:content>
                   </Item>

--- a/app/templates/organizations/organization/core-data/index.hbs
+++ b/app/templates/organizations/organization/core-data/index.hbs
@@ -127,6 +127,7 @@
                   </:content>
                 </Item>
               {{/if}}
+              {{! FIXME: This broke after changing the `locatedWithin` to `hasMany` }}
               {{#if
                 (and
                   @model.organization.scope.locatedWithin

--- a/app/templates/organizations/organization/core-data/index.hbs
+++ b/app/templates/organizations/organization/core-data/index.hbs
@@ -127,17 +127,13 @@
                   </:content>
                 </Item>
               {{/if}}
-              {{! FIXME: This broke after changing the `locatedWithin` to `hasMany` }}
               {{#if
-                (and
-                  @model.organization.scope.locatedWithin
-                  @model.organization.isMunicipality
-                )
+                (and @model.organization.displayRegion @model.region.label)
               }}
                 <Item>
                   <:label>Regio</:label>
                   <:content>
-                    {{@model.organization.scope.locatedWithin.label}}
+                    {{@model.region.label}}
                   </:content>
                 </Item>
               {{/if}}
@@ -155,14 +151,6 @@
                   @model.organization.isPevaProvince
                 )
               }}
-                {{#if @model.region.label}}
-                  <Item>
-                    <:label>Regio</:label>
-                    <:content>
-                      {{@model.region.label}}
-                    </:content>
-                  </Item>
-                {{/if}}
                 {{#if @model.organization.expectedEndDate}}
                   <Item>
                     <:label>Geplande einddatum</:label>

--- a/app/templates/organizations/organization/core-data/index.hbs
+++ b/app/templates/organizations/organization/core-data/index.hbs
@@ -140,13 +140,19 @@
                   </:content>
                 </Item>
               {{/if}}
+              {{#if @model.organization.isAdministrativeUnit}}
+                <Item>
+                  <:label>Werkingsgebied</:label>
+                  <:content>{{@model.scopeLabel}}</:content>
+                </Item>
+              {{/if}}
               {{#if
-                  (or
-                    @model.organization.isIgs
-                    @model.organization.isOcmwAssociation
-                    @model.organization.isPevaMunicipality
-                    @model.organization.isPevaProvince
-                  )
+                (or
+                  @model.organization.isIgs
+                  @model.organization.isOcmwAssociation
+                  @model.organization.isPevaMunicipality
+                  @model.organization.isPevaProvince
+                )
               }}
                 {{#if @model.region.label}}
                   <Item>

--- a/app/utils/split-array-in-groups.js
+++ b/app/utils/split-array-in-groups.js
@@ -1,0 +1,7 @@
+export default function splitArrayIntoGroups(array, groupSize) {
+  const groups = [];
+  for (let i = 0; i < array.length; i += groupSize) {
+    groups.push(array.slice(i, i + groupSize));
+  }
+  return groups;
+}

--- a/tests/unit/models/administrative-unit-test.js
+++ b/tests/unit/models/administrative-unit-test.js
@@ -18,11 +18,12 @@ module('Unit | Model | administrative unit', function (hooks) {
       const isValid = await model.validate();
 
       assert.false(isValid);
-      assert.strictEqual(Object.keys(model.error).length, 3);
+      assert.strictEqual(Object.keys(model.error).length, 4);
       assert.propContains(model.error, {
         legalName: { message: 'Vul de juridische naam in' },
         classification: { message: 'Selecteer een optie' },
         organizationStatus: { message: 'Selecteer een optie' },
+        scope: { message: 'Selecteer een optie' },
       });
     });
 
@@ -39,13 +40,14 @@ module('Unit | Model | administrative unit', function (hooks) {
       const isValid = await model.validate();
 
       assert.false(isValid);
-      assert.strictEqual(Object.keys(model.error).length, 3);
+      assert.strictEqual(Object.keys(model.error).length, 4);
       assert.propContains(model.error, {
         legalName: { message: 'Vul de juridische naam in' },
         expectedEndDate: {
           message: 'De datum mag niet in het verleden liggen',
         },
         organizationStatus: { message: 'Selecteer een optie' },
+        scope: { message: 'Selecteer een optie' },
       });
     });
 
@@ -78,11 +80,12 @@ module('Unit | Model | administrative unit', function (hooks) {
         const isValid = await model.validate({ creatingNewOrganization: true });
 
         assert.false(isValid);
-        assert.strictEqual(Object.keys(model.error).length, 3);
+        assert.strictEqual(Object.keys(model.error).length, 4);
         assert.propContains(model.error, {
           legalName: { message: 'Vul de juridische naam in' },
           organizationStatus: { message: 'Selecteer een optie' },
           memberships: { message: 'Selecteer een optie' },
+          scope: { message: 'Selecteer een optie' },
         });
       });
     });
@@ -117,11 +120,12 @@ module('Unit | Model | administrative unit', function (hooks) {
         const isValid = await model.validate({ creatingNewOrganization: true });
 
         assert.false(isValid);
-        assert.strictEqual(Object.keys(model.error).length, 3);
+        assert.strictEqual(Object.keys(model.error).length, 4);
         assert.propContains(model.error, {
           legalName: { message: 'Vul de juridische naam in' },
           organizationStatus: { message: 'Selecteer een optie' },
           memberships: { message: 'Selecteer een optie' },
+          scope: { message: 'Selecteer een optie' },
         });
       });
     });
@@ -157,10 +161,11 @@ module('Unit | Model | administrative unit', function (hooks) {
         const isValid = await model.validate({ creatingNewOrganization: true });
 
         assert.false(isValid);
-        assert.strictEqual(Object.keys(model.error).length, 2);
+        assert.strictEqual(Object.keys(model.error).length, 3);
         assert.propContains(model.error, {
           legalName: { message: 'Vul de juridische naam in' },
           organizationStatus: { message: 'Selecteer een optie' },
+          scope: { message: 'Selecteer een optie' },
         });
       });
     });
@@ -193,10 +198,11 @@ module('Unit | Model | administrative unit', function (hooks) {
         const isValid = await model.validate();
 
         assert.false(isValid);
-        assert.strictEqual(Object.keys(model.error).length, 2);
+        assert.strictEqual(Object.keys(model.error).length, 3);
         assert.propContains(model.error, {
           legalName: { message: 'Vul de juridische naam in' },
           organizationStatus: { message: 'Selecteer een optie' },
+          scope: { message: 'Selecteer een optie' },
         });
       });
     });
@@ -230,10 +236,11 @@ module('Unit | Model | administrative unit', function (hooks) {
         const isValid = await model.validate();
 
         assert.false(isValid);
-        assert.strictEqual(Object.keys(model.error).length, 2);
+        assert.strictEqual(Object.keys(model.error).length, 3);
         assert.propContains(model.error, {
           legalName: { message: 'Vul de juridische naam in' },
           organizationStatus: { message: 'Selecteer een optie' },
+          scope: { message: 'Selecteer een optie' },
         });
       });
     });
@@ -269,10 +276,11 @@ module('Unit | Model | administrative unit', function (hooks) {
         const isValid = await model.validate();
 
         assert.false(isValid);
-        assert.strictEqual(Object.keys(model.error).length, 2);
+        assert.strictEqual(Object.keys(model.error).length, 3);
         assert.propContains(model.error, {
           legalName: { message: 'Vul de juridische naam in' },
           organizationStatus: { message: 'Selecteer een optie' },
+          scope: { message: 'Selecteer een optie' },
         });
       });
     });

--- a/tests/unit/models/central-worship-service-test.js
+++ b/tests/unit/models/central-worship-service-test.js
@@ -18,11 +18,12 @@ module('Unit | Model | central worship service', function (hooks) {
       const isValid = await model.validate();
 
       assert.false(isValid);
-      assert.strictEqual(Object.keys(model.error).length, 3);
+      assert.strictEqual(Object.keys(model.error).length, 4);
       assert.propContains(model.error, {
         legalName: { message: 'Vul de juridische naam in' },
         classification: { message: 'Selecteer een optie' },
         organizationStatus: { message: 'Selecteer een optie' },
+        scope: { message: 'Selecteer een optie' },
       });
     });
 
@@ -38,13 +39,14 @@ module('Unit | Model | central worship service', function (hooks) {
       const isValid = await model.validate({ creatingNewOrganization: true });
 
       assert.false(isValid);
-      assert.strictEqual(Object.keys(model.error).length, 4);
+      assert.strictEqual(Object.keys(model.error).length, 5);
 
       assert.propContains(model.error, {
         legalName: { message: 'Vul de juridische naam in' },
         organizationStatus: { message: 'Selecteer een optie' },
         recognizedWorshipType: { message: 'Selecteer een optie' },
         memberships: { message: 'Selecteer een optie' },
+        scope: { message: 'Selecteer een optie' },
       });
     });
 
@@ -62,11 +64,12 @@ module('Unit | Model | central worship service', function (hooks) {
       const isValid = await model.validate({ creatingNewOrganization: true });
 
       assert.false(isValid);
-      assert.strictEqual(Object.keys(model.error).length, 3);
+      assert.strictEqual(Object.keys(model.error).length, 4);
       assert.propContains(model.error, {
         legalName: { message: 'Vul de juridische naam in' },
         organizationStatus: { message: 'Selecteer een optie' },
         recognizedWorshipType: { message: 'Selecteer een optie' },
+        scope: { message: 'Selecteer een optie' },
       });
     });
 
@@ -82,11 +85,12 @@ module('Unit | Model | central worship service', function (hooks) {
       const isValid = await model.validate();
 
       assert.false(isValid);
-      assert.strictEqual(Object.keys(model.error).length, 3);
+      assert.strictEqual(Object.keys(model.error).length, 4);
       assert.propContains(model.error, {
         legalName: { message: 'Vul de juridische naam in' },
         organizationStatus: { message: 'Selecteer een optie' },
         recognizedWorshipType: { message: 'Selecteer een optie' },
+        scope: { message: 'Selecteer een optie' },
       });
     });
 
@@ -104,11 +108,12 @@ module('Unit | Model | central worship service', function (hooks) {
       const isValid = await model.validate({ creatingNewOrganization: true });
 
       assert.false(isValid);
-      assert.strictEqual(Object.keys(model.error).length, 3);
+      assert.strictEqual(Object.keys(model.error).length, 4);
       assert.propContains(model.error, {
         legalName: { message: 'Vul de juridische naam in' },
         organizationStatus: { message: 'Selecteer een optie' },
         recognizedWorshipType: { message: 'Selecteer een optie' },
+        scope: { message: 'Selecteer een optie' },
       });
     });
   });

--- a/tests/unit/models/worship-administrative-unit-test.js
+++ b/tests/unit/models/worship-administrative-unit-test.js
@@ -17,11 +17,12 @@ module('Unit | Model | worship administrative unit', function (hooks) {
       const isValid = await model.validate();
 
       assert.false(isValid);
-      assert.strictEqual(Object.keys(model.error).length, 3);
+      assert.strictEqual(Object.keys(model.error).length, 4);
       assert.propContains(model.error, {
         legalName: { message: 'Vul de juridische naam in' },
         classification: { message: 'Selecteer een optie' },
         organizationStatus: { message: 'Selecteer een optie' },
+        scope: { message: 'Selecteer een optie' },
       });
     });
   });

--- a/tests/unit/models/worship-service-test.js
+++ b/tests/unit/models/worship-service-test.js
@@ -20,11 +20,12 @@ module('Unit | Model | worship service', function (hooks) {
       const isValid = await model.validate();
 
       assert.false(isValid);
-      assert.strictEqual(Object.keys(model.error).length, 3);
+      assert.strictEqual(Object.keys(model.error).length, 4);
       assert.propContains(model.error, {
         legalName: { message: 'Vul de juridische naam in' },
         classification: { message: 'Selecteer een optie' },
         organizationStatus: { message: 'Selecteer een optie' },
+        scope: { message: 'Selecteer een optie' },
       });
     });
 
@@ -40,13 +41,14 @@ module('Unit | Model | worship service', function (hooks) {
       const isValid = await model.validate({ creatingNewOrganization: true });
 
       assert.false(isValid);
-      assert.strictEqual(Object.keys(model.error).length, 4);
+      assert.strictEqual(Object.keys(model.error).length, 5);
 
       assert.propContains(model.error, {
         legalName: { message: 'Vul de juridische naam in' },
         organizationStatus: { message: 'Selecteer een optie' },
         recognizedWorshipType: { message: 'Selecteer een optie' },
         memberships: { message: 'Selecteer een optie' },
+        scope: { message: 'Selecteer een optie' },
       });
     });
 
@@ -64,11 +66,12 @@ module('Unit | Model | worship service', function (hooks) {
       const isValid = await model.validate({ creatingNewOrganization: true });
 
       assert.false(isValid);
-      assert.strictEqual(Object.keys(model.error).length, 3);
+      assert.strictEqual(Object.keys(model.error).length, 4);
       assert.propContains(model.error, {
         legalName: { message: 'Vul de juridische naam in' },
         organizationStatus: { message: 'Selecteer een optie' },
         recognizedWorshipType: { message: 'Selecteer een optie' },
+        scope: { message: 'Selecteer een optie' },
       });
     });
 
@@ -84,11 +87,12 @@ module('Unit | Model | worship service', function (hooks) {
       const isValid = await model.validate();
 
       assert.false(isValid);
-      assert.strictEqual(Object.keys(model.error).length, 3);
+      assert.strictEqual(Object.keys(model.error).length, 4);
       assert.propContains(model.error, {
         legalName: { message: 'Vul de juridische naam in' },
         organizationStatus: { message: 'Selecteer een optie' },
         recognizedWorshipType: { message: 'Selecteer een optie' },
+        scope: { message: 'Selecteer een optie' },
       });
     });
 
@@ -106,11 +110,12 @@ module('Unit | Model | worship service', function (hooks) {
       const isValid = await model.validate({ creatingNewOrganization: true });
 
       assert.false(isValid);
-      assert.strictEqual(Object.keys(model.error).length, 3);
+      assert.strictEqual(Object.keys(model.error).length, 4);
       assert.propContains(model.error, {
         legalName: { message: 'Vul de juridische naam in' },
         organizationStatus: { message: 'Selecteer een optie' },
         recognizedWorshipType: { message: 'Selecteer een optie' },
+        scope: { message: 'Selecteer een optie' },
       });
     });
 
@@ -133,11 +138,16 @@ module('Unit | Model | worship service', function (hooks) {
       const localInvolvementB = this.store().createRecord('local-involvement', {
         percentage: 50,
       });
+      const scope = this.store().createRecord('location', {
+        label: 'scope label',
+        level: 'scope level',
+      });
       const worshipService = this.store().createRecord('worship-service', {
         legalName: 'Foo',
         classification,
         organizationStatus,
         recognizedWorshipType,
+        scope,
         involvements: [localInvolvementA, localInvolvementB],
       });
 


### PR DESCRIPTION
OP is extended with functionality to allow users to consult and edit the scope of operation (*nl. werkingsgebied*) for an administrative unit. This PR introduces the necessary frontend changes to use a newly introduced backend service for this functionality.

## Overview of functionality for MVP
### Consult scope of operation
A new field is added to the core data page for organisations to display the organisation's scope of operation. The expected value for this field is a list of all municipality-level locations that are part of the organisation's scope of operation. (Yes this can become very long, just try opening a province :worried:)

### Edit scope of operation
The form to edit the core data for an organisation should allow users to select one or more municipality-level locations as its scope of operation. Similarly, the new organisation form should allow users to select appropriate locations when creating a new administrative unit.

The scope of operation is mandatory for all administrative units and an error should be shown if the users fails to select at least one value.

For municipalities and provinces their scope of operation cannot be edited.

## Proposed solution
This PR introduces a new service in the frontend that acts as a wrapper around the new `scope-of-operation-service` introduced in the backend. This wrapper service essentially translates between the frontend's models and the UUIDs required/returned by the backend service. Putting this logic within a single service allows to reuse it within different routes, such as the edit or new organisation route, without having to duplicate this logic.

Furthermore, a new component is introduced that allows users to select multiple municipality-level locations. This component is similar to the already existing components to select multiple organisations. This new component is added to the edit core data and new organisation form.

## Determine region for organisations
For some kinds organisations (municipalities, IGSs, PEVAs, a OCMW associations) their core data page contains an optional region field. The value of this field is also based on the location that is assigned as the organisation' scope of operation. More specifically, for municipalities it is the reference region in which its corresponding location is located. For the other kinds of organisations it is the reference region of the municipality in which their primary site is located.

The existing functionality for this mapping broke due to a required model change in `LocationModel` to allow that a location is contained within multiple other locations. Consequently, it was no longer possible to simply follow the `locatedWithin` relation as this changed to a `hasMany`. Therefore, this functionality was also revised to search for the reference region in which the municipality is located. This relies on the fact a municipality is at most in 1 reference regions, thus that there is no overlap between reference regions.

## Related PRs:
- Backend: [#550](https://github.com/lblod/app-organization-portal/pull/550)
- Service: [#1](https://github.com/lblod/scope-of-operation-service/pull/1)

## Related tickets:
- OP-3203
- OP-3600