### PR TITLE
feat: do not allow users to remove relationships between certain classes of organisations

### DIFF
--- a/app/components/related-organizations-edit-table.hbs
+++ b/app/components/related-organizations-edit-table.hbs
@@ -104,6 +104,7 @@
         <td>
           <AuButton
             @alert={{true}}
+            @disabled={{membership.isNotRemovableByUser}}
             @icon="bin"
             @iconAlignment="left"
             @skin="link"

--- a/app/models/membership.js
+++ b/app/models/membership.js
@@ -148,6 +148,14 @@ export default class MembershipModel extends AbstractValidationModel {
     return this.role?.get('participatesIn');
   }
 
+  get isNotRemovableByUser() {
+    const org = this.belongsTo('organization').value();
+    const member = this.belongsTo('member').value();
+    const role = this.belongsTo('role').value();
+
+    return org?.isProvince && member?.isMunicipality && role?.hasRelationWith;
+  }
+
   /**
    * Check whether this membership is equal to a given one. Two memberships are
    * considered equal their respective organizations, members, and roles have

--- a/app/models/membership.js
+++ b/app/models/membership.js
@@ -154,6 +154,7 @@ export default class MembershipModel extends AbstractValidationModel {
     const role = this.belongsTo('role').value();
 
     return (
+      !this.isNew &&
       role?.hasRelationWith &&
       ((org?.isProvince && member?.isMunicipality) ||
         (org?.isProvince && member?.isOCMW) ||

--- a/app/models/membership.js
+++ b/app/models/membership.js
@@ -153,7 +153,12 @@ export default class MembershipModel extends AbstractValidationModel {
     const member = this.belongsTo('member').value();
     const role = this.belongsTo('role').value();
 
-    return org?.isProvince && member?.isMunicipality && role?.hasRelationWith;
+    return (
+      role?.hasRelationWith &&
+      ((org?.isProvince && member?.isMunicipality) ||
+        (org?.isProvince && member?.isOCMW) ||
+        (org?.isMunicipality && member?.isOCMW))
+    );
   }
 
   /**


### PR DESCRIPTION
Users should not be able to removes relationships between
- a municipality and their province; and
- an OCMW and their municipality or province.

These relationships are fixed and can only changes as part of municipality mergers.

## Proposed solution
Disable the remove button on rows that correspond to memberships as described above.

## How to test
1. Log in as non-worship editor
2. Select a municipality or OCMW from the overview table, any should do
3. Go to the related organisations (*nl. Gerelateerde organisaties*) tab
4. Go to the edit form using the edit (*nl. Bewerk*) button in the top-right corner
5. In the edit form the remove (*nl. Verwijder*) button in the last column should be disabled for rows corresponding to the relations described above. (For OCMWs also read the second bullet in the notes section below, there is a data issue.)

## Notes
- Originally, the related ticket only concerned relations between provinces and municipalities. As the underlying membership resources for such relations are located in the read-only `shared` graph they could not be removed by users anyway as the authorisation service would block such requests. But since the frontend did not show this it caused strange behaviour where a user could removed relation but it would just reappear after saving.
- The data contains duplicate relation between municipalities and OCMWs. There are duplicate memberships where the OCMW is the `org:organization` and the municipality is the `org:member` of the membership. These memberships are not correct and should be removed in a separate PR/ticket. Therefore, I did not consider preventing their removal as part of the functionality added here. In summary, for OCMWs (and municipalities) the edit related organisations form will contain two rows relating it with a municipality (OCMW), where one cannot be removed whereas to other one can. (A ticket was created for this: OP-3634)

## Related tickets
- OP-3620