### PR TITLE
fix: disable editing scope of operation for districts

### DIFF
--- a/app/models/administrative-unit.js
+++ b/app/models/administrative-unit.js
@@ -216,4 +216,8 @@ export default class AdministrativeUnitModel extends OrganizationModel {
       this.isVlaamseGemeenschapscommissie
     );
   }
+
+  get disableScopeEdits() {
+    return this.isDistrict || this.isMunicipality || this.isProvince;
+  }
 }

--- a/app/templates/organizations/organization/core-data/edit.hbs
+++ b/app/templates/organizations/organization/core-data/edit.hbs
@@ -185,10 +185,7 @@
                       <LocationMultipleSelect
                         @selected={{this.locationsInScope}}
                         @onChange={{fn (mut this.locationsInScope)}}
-                        @disabled={{or
-                          @model.organization.isMunicipality
-                          @model.organization.isProvince
-                        }}
+                        @disabled={{@model.organization.disableScopeEdits}}
                         @provinceLocations={{@model.provinceLocations}}
                         @error={{@model.organization.error.scope}}
                         @id="locations-select"


### PR DESCRIPTION
Similar to municipalities and provinces, the scope of operation for districts should not be editable by the user.

## How to test
0. Launch a local frontend built from this branch.
1. Log in as a non-worship editor.
2. Find a district type organisation in the organisations overview table, you can filter by type in the sidebar.
3. On the core data page for the district, click the edit button in the top right corner.
4. In the core data edit form, the input field for the scope of operation (*nl. Werkingsgebied*) should be greyed out and not be editable.

## Notes
Together with [#3](https://github.com/lblod/scope-of-operation-service/pull/3) for the scope of operation service this PR is intended to fix the bug reported in the linked ticket. To test whether it solves the reported bug:

0. Configure your OP stack to use a locally built version of scope of operation service, built from the branch of the linked PR.
1. Log in as a non-worship editor.
2. Find a district type organisation in the organisations overview table, you can filter by type in the sidebar.
3. For districts with a scope of operation (*nl. Werkingsgebied*)set in their core data page:
   - the same scope of operation should be visible on the edit form of that page (the bug was that the scope of operation disappeared); and
   - the scope of operation should **not** be editable.
   For districts for which no scope of operation is set:
   - the scope of operations field should be empty on both the view and edit page; and
   - the scope of operation should **not** be editable.

## Related tickets
- OP-3647