### PR TITLE
OP-3668: Frontend - Improvements on creating new organisation in Brussel municipality 

### DIFF
--- a/app/components/address-register-selector.hbs
+++ b/app/components/address-register-selector.hbs
@@ -10,7 +10,7 @@
     @onChange={{perform this.selectSuggestion}}
     @loadingMessage="Aan het laden..."
     @searchEnabled={{true}}
-    @noMatchesMessage="Geen resultaten"
+    @noMatchesMessage="Het adres is niet gevonden, vul het adres manueel in"
     @searchMessage="Typ om te zoeken"
     @beforeOptionsComponent={{component "power-select/before-options-with-pre-filled-text" addressSuggestion=this.addressSuggestion}}
     as |suggestion|

--- a/app/components/location-multiple-select.js
+++ b/app/components/location-multiple-select.js
@@ -29,15 +29,13 @@ export default class LocationMultipleSelectComponent extends Component {
   }
 
   extractProvinceGroups(provinces, municipalities) {
-     // Existing grouped provinces
     const provinceGroups = provinces
       .map((province) => this.createGroupForProvince(province, municipalities))
       .filter((group) => group.options.length > 0);
 
-    // 🆕 Handle municipalities that aren't located within any province
     const unlinkedMunicipalities = municipalities.filter(
       (municipality) =>
-        !provinces.some((province) => municipality.isLocatedWithin(province))
+        !provinces.some((province) => municipality.isLocatedWithin(province)),
     );
 
     if (unlinkedMunicipalities.length > 0) {

--- a/app/components/location-multiple-select.js
+++ b/app/components/location-multiple-select.js
@@ -29,9 +29,25 @@ export default class LocationMultipleSelectComponent extends Component {
   }
 
   extractProvinceGroups(provinces, municipalities) {
-    return provinces
+     // Existing grouped provinces
+    const provinceGroups = provinces
       .map((province) => this.createGroupForProvince(province, municipalities))
       .filter((group) => group.options.length > 0);
+
+    // 🆕 Handle municipalities that aren't located within any province
+    const unlinkedMunicipalities = municipalities.filter(
+      (municipality) =>
+        !provinces.some((province) => municipality.isLocatedWithin(province))
+    );
+
+    if (unlinkedMunicipalities.length > 0) {
+      provinceGroups.push({
+        groupName: 'Buiten Vlaams Gewest',
+        options: unlinkedMunicipalities,
+      });
+    }
+
+    return provinceGroups;
   }
 
   createGroupForProvince(province, municipalities) {

--- a/app/routes/organizations/index.js
+++ b/app/routes/organizations/index.js
@@ -101,6 +101,8 @@ export default class OrganizationsIndexRoute extends Route {
       filter[':query:status_id'] = `(_exists_:status_id)`;
     }
 
+    filter[':has-no:source'] = true;
+
     return yield this.muSearch.search({
       index: 'organizations',
       page: params.page,


### PR DESCRIPTION
Frontend changes for the tickets under OP-3668. Changed the message for when no adress found and extended the werkingsgebieden selector and added a filter for the source so that the municipalities aren´t shown in the main organizations page. 

### Tickets
User Story:
- OP-3668

Specific tickets:
- OP-3671
- OP-3672
- OP-3673