### PR TITLE
OP-3735 Changed KBO number to test the change, now i can't change it back to the right one

### DIFF
--- a/app/models/identifier.js
+++ b/app/models/identifier.js
@@ -37,7 +37,7 @@ export default class IdentifierModel extends AbstractValidationModel {
             if (!localId.match(/^\d{10}$/)) {
               return helpers.message('Vul het (tiencijferige) KBO nummer in.');
             }
-            // KBO must be unique (valid only when changed)
+            // KBO must be unique (valid only when changed) #TODO: Move this check to the backend. Frontend does not have access to the full dataset and cannot reliably validate this.
             const changedAttributes = (
               await this.structuredIdentifier
             ).changedAttributes();

--- a/app/models/identifier.js
+++ b/app/models/identifier.js
@@ -37,7 +37,7 @@ export default class IdentifierModel extends AbstractValidationModel {
             if (!localId.match(/^\d{10}$/)) {
               return helpers.message('Vul het (tiencijferige) KBO nummer in.');
             }
-            // KBO must be unique (valid only when changed) #TODO: Move this check to the backend. Frontend does not have access to the full dataset and cannot reliably validate this.
+            // KBO must be unique (valid only when changed) #TODO: Move this check to the backend. Frontend does not have access to the full dataset.
             const changedAttributes = (
               await this.structuredIdentifier
             ).changedAttributes();

--- a/app/models/identifier.js
+++ b/app/models/identifier.js
@@ -54,9 +54,13 @@ export default class IdentifierModel extends AbstractValidationModel {
                 include: 'identifiers.structured-identifier',
               });
 
-              if (records.length > 0) {
+            let conflicts = records.filter(
+                (r) => r.constructor.modelName !== 'kbo-organization'
+              );
+
+              if (conflicts.length > 0) {
                 return helpers.message('Dit KBO nummer is al in gebruik.', {
-                  organization: records.at(0),
+                  organization: conflicts.at(0),
                 });
               }
             }

--- a/app/models/identifier.js
+++ b/app/models/identifier.js
@@ -54,8 +54,8 @@ export default class IdentifierModel extends AbstractValidationModel {
                 include: 'identifiers.structured-identifier',
               });
 
-            let conflicts = records.filter(
-                (r) => r.constructor.modelName !== 'kbo-organization'
+              let conflicts = records.filter(
+                (r) => r.constructor.modelName !== 'kbo-organization',
               );
 
               if (conflicts.length > 0) {


### PR DESCRIPTION
**Problem:** In QA a KBO number was changed to test a change and then they were unable to change it back, since they got the message "Dit KBO nummer is al in gebruik". The reason for this was that the linked KboOrganisation still had this KBO number and the validation gave an error on that.

**Fix:** Edit to the validation so that it allows the same KBO Number if it's only on a type 'kbo-organization'. It still gives an error if its on a administrative-unit

**Test:** Change a KBO number to not the right one and see if you can change it back. Also good to test if you cannot change it to an already in use KBO number. (I also tested this).


### Ticket
OP-3735