### PR TITLE
[OP-3794] Add new organization types

### DIFF
--- a/app/components/classification-multiple-select.hbs
+++ b/app/components/classification-multiple-select.hbs
@@ -6,7 +6,7 @@
     @loadingMessage="Aan het laden..."
     @noMatchesMessage="Geen resultaten"
     @searchMessage="Typ om te zoeken"
-    @options={{this.classifications.value}}
+    @options={{this.groupedClassifications}}
     @selected={{this.selectedClassifications}}
     @onChange={{@onChange}}
     @triggerId={{@id}}

--- a/app/components/classification-multiple-select.js
+++ b/app/components/classification-multiple-select.js
@@ -6,6 +6,7 @@ import { CENTRAL_WORSHIP_SERVICE_BLACKLIST } from 'frontend-organization-portal/
 import { CLASSIFICATION } from 'frontend-organization-portal/models/administrative-unit-classification-code';
 import { tracked } from '@glimmer/tracking';
 import { getClassificationIdsForRole } from 'frontend-organization-portal/utils/classification-identifiers';
+import { convertClassificationToGroups } from '../utils/group-classifications';
 
 export default class ClassificationMultipleSelectComponent extends Component {
   @service store;
@@ -18,6 +19,14 @@ export default class ClassificationMultipleSelectComponent extends Component {
     this.args.selectedOrganizationTypes,
     this.args.selectedRecognizedWorshipTypeId,
   ]);
+
+  get groupedClassifications() {
+    if (this.classifications.isRunning) {
+      return [];
+    }
+
+    return convertClassificationToGroups(this.classifications.value);
+  }
 
   get selectedClassifications() {
     let selectionArray = [];

--- a/app/components/classification-select.hbs
+++ b/app/components/classification-select.hbs
@@ -4,13 +4,13 @@
     @loadingMessage="Aan het laden..."
     @noMatchesMessage="Geen resultaten"
     @searchMessage="Typ om te zoeken"
-    @searchField="label"
+    @searchField="searchLabel"
     @options={{this.classifications.value}}
     @selected={{@selected}}
     @onChange={{@onChange}}
     @triggerId={{@id}}
     as |classification|
   >
-    {{classification.label}}
+    {{classification.label}}{{#if classification.altLabel}} ({{classification.altLabel}}){{/if}}
   </PowerSelect>
 </div>

--- a/app/constants/Classification.js
+++ b/app/constants/Classification.js
@@ -58,3 +58,11 @@ export const CorporationOtherCodeList = [CLASSIFICATION.CORPORATION_OTHER.id];
 export const VlaamseGemeenschapscommissieCodeList = [
   CLASSIFICATION.VLAAMSE_GEMEENSCHAPSCOMMISSIE.id,
 ];
+
+export const InterlokaleVerenigingCodeList = [
+  CLASSIFICATION.INTERLOKALE_VERENIGING.id,
+];
+export const VervoerregioraadCodeList = [CLASSIFICATION.VERVOERREGIORAAD.id];
+export const ZorgraadCodeList = [CLASSIFICATION.ZORGRAAD.id];
+export const BosgroepCodeList = [CLASSIFICATION.BOSGROEP.id];
+export const WoonmaatschappijCodeList = [CLASSIFICATION.WOONMAATSCHAPPIJ.id];

--- a/app/constants/organization-types.js
+++ b/app/constants/organization-types.js
@@ -2,4 +2,5 @@ export const ORGANIZATION_TYPES = Object.freeze({
   ADMINISTRATIVE_UNIT: 'Bestuurseenheid',
   ASSOCIATION: 'Vereniging',
   CORPORATION: 'Vennootschap',
+  PARTNERSHIP: 'Samenwerkingsverband',
 });

--- a/app/controllers/organizations/new.js
+++ b/app/controllers/organizations/new.js
@@ -35,13 +35,19 @@ export default class OrganizationsNewController extends Controller {
 
   @tracked locations;
 
+  // ILV and Vervoerregioraad have no KBO number, so KBO is optional for them.
+  get requiresKbo() {
+    const model = this.currentOrganizationModel;
+    return !(model?.isInterlokaleVereniging || model?.isVervoerregioraad);
+  }
+
   get hasValidationErrors() {
     return (
       this.currentOrganizationModel.error ||
       this.model.address.error ||
       this.model.contact.error ||
       this.model.secondaryContact.error ||
-      this.model.identifierKBO.error ||
+      (this.requiresKbo && this.model.identifierKBO.error) ||
       this.model.identifierSharepoint.error ||
       this.memberships.some((membership) => membership.error) ||
       this.membershipsOfOrganizations.some((membership) => membership.error)
@@ -368,6 +374,9 @@ export default class OrganizationsNewController extends Controller {
         CLASSIFICATION.WOONZORGVERENIGING_OF_WOONZORGVENNOOTSCHAP.id,
         CLASSIFICATION.ASSOCIATION_OTHER.id,
         CLASSIFICATION.CORPORATION_OTHER.id,
+        CLASSIFICATION.ZORGRAAD.id,
+        CLASSIFICATION.BOSGROEP.id,
+        CLASSIFICATION.WOONMAATSCHAPPIJ.id,
       ].includes(classificationCodeId)
     ) {
       return this.store.createRecord('registered-organization');
@@ -389,6 +398,8 @@ export default class OrganizationsNewController extends Controller {
         CLASSIFICATION.AUTONOME_VERZORGINGSINSTELLING.id,
         CLASSIFICATION.PEVA_MUNICIPALITY.id,
         CLASSIFICATION.PEVA_PROVINCE.id,
+        CLASSIFICATION.INTERLOKALE_VERENIGING.id,
+        CLASSIFICATION.VERVOERREGIORAAD.id,
       ].includes(classificationCodeId)
     ) {
       return this.store.createRecord('administrative-unit');
@@ -589,7 +600,7 @@ export default class OrganizationsNewController extends Controller {
 
     yield Promise.all([
       this.currentOrganizationModel.validate({ creatingNewOrganization: true }),
-      identifierKBO.validate(),
+      this.requiresKbo ? identifierKBO.validate() : Promise.resolve(),
       identifierSharepoint.validate(),
     ]);
 
@@ -605,9 +616,13 @@ export default class OrganizationsNewController extends Controller {
     }
 
     if (!this.hasValidationErrors) {
-      structuredIdentifierKBO = setEmptyStringsToNull(structuredIdentifierKBO);
-      yield structuredIdentifierKBO.save();
-      yield identifierKBO.save();
+      if (this.requiresKbo) {
+        structuredIdentifierKBO = setEmptyStringsToNull(
+          structuredIdentifierKBO,
+        );
+        yield structuredIdentifierKBO.save();
+        yield identifierKBO.save();
+      }
 
       structuredIdentifierSharepoint = setEmptyStringsToNull(
         structuredIdentifierSharepoint,
@@ -655,10 +670,11 @@ export default class OrganizationsNewController extends Controller {
         yield primarySite.save();
         this.currentOrganizationModel.primarySite = primarySite;
       }
-      (yield this.currentOrganizationModel.identifiers).push(
-        identifierKBO,
-        identifierSharepoint,
-      );
+      const identifiers = yield this.currentOrganizationModel.identifiers;
+      if (this.requiresKbo) {
+        identifiers.push(identifierKBO);
+      }
+      identifiers.push(identifierSharepoint);
 
       this.currentOrganizationModel = setEmptyStringsToNull(
         this.currentOrganizationModel,
@@ -680,10 +696,12 @@ export default class OrganizationsNewController extends Controller {
         method: 'POST',
       });
 
-      const syncKboData = `/kbo-data-sync/${structuredIdentifierKBO.id}`;
-      yield fetch(syncKboData, {
-        method: 'POST',
-      });
+      if (this.requiresKbo) {
+        const syncKboData = `/kbo-data-sync/${structuredIdentifierKBO.id}`;
+        yield fetch(syncKboData, {
+          method: 'POST',
+        });
+      }
 
       this.router.replaceWith(
         'organizations.organization',

--- a/app/controllers/organizations/new.js
+++ b/app/controllers/organizations/new.js
@@ -600,7 +600,7 @@ export default class OrganizationsNewController extends Controller {
 
     yield Promise.all([
       this.currentOrganizationModel.validate({ creatingNewOrganization: true }),
-      this.requiresKbo ? identifierKBO.validate() : Promise.resolve(),
+      this.requiresKbo ? identifierKBO.validate() : identifierKBO.resetErrors(),
       identifierSharepoint.validate(),
     ]);
 

--- a/app/controllers/organizations/new.js
+++ b/app/controllers/organizations/new.js
@@ -9,6 +9,7 @@ import fetch from 'fetch';
 import { CLASSIFICATION } from 'frontend-organization-portal/models/administrative-unit-classification-code';
 import isContactEditableOrganization from 'frontend-organization-portal/utils/editable-contact-data';
 import { MEMBERSHIP_ROLES_MAPPING } from 'frontend-organization-portal/models/membership-role';
+import requiresKbo from '../../helpers/requires-kbo';
 
 export default class OrganizationsNewController extends Controller {
   @service router;
@@ -35,19 +36,14 @@ export default class OrganizationsNewController extends Controller {
 
   @tracked locations;
 
-  // ILV and Vervoerregioraad have no KBO number, so KBO is optional for them.
-  get requiresKbo() {
-    const model = this.currentOrganizationModel;
-    return !(model?.isInterlokaleVereniging || model?.isVervoerregioraad);
-  }
-
   get hasValidationErrors() {
     return (
       this.currentOrganizationModel.error ||
       this.model.address.error ||
       this.model.contact.error ||
       this.model.secondaryContact.error ||
-      (this.requiresKbo && this.model.identifierKBO.error) ||
+      (requiresKbo(this.currentOrganizationModel) &&
+        this.model.identifierKBO.error) ||
       this.model.identifierSharepoint.error ||
       this.memberships.some((membership) => membership.error) ||
       this.membershipsOfOrganizations.some((membership) => membership.error)
@@ -598,9 +594,13 @@ export default class OrganizationsNewController extends Controller {
         ? yield this.scopeOfOperation.getScopeForLocations(...this.locations)
         : null;
 
+    const requiresKboNumber = requiresKbo(this.currentOrganizationModel);
+
     yield Promise.all([
       this.currentOrganizationModel.validate({ creatingNewOrganization: true }),
-      this.requiresKbo ? identifierKBO.validate() : identifierKBO.resetErrors(),
+      requiresKboNumber
+        ? identifierKBO.validate()
+        : identifierKBO.resetErrors(),
       identifierSharepoint.validate(),
     ]);
 
@@ -616,7 +616,7 @@ export default class OrganizationsNewController extends Controller {
     }
 
     if (!this.hasValidationErrors) {
-      if (this.requiresKbo) {
+      if (requiresKboNumber) {
         structuredIdentifierKBO = setEmptyStringsToNull(
           structuredIdentifierKBO,
         );
@@ -671,7 +671,7 @@ export default class OrganizationsNewController extends Controller {
         this.currentOrganizationModel.primarySite = primarySite;
       }
       const identifiers = yield this.currentOrganizationModel.identifiers;
-      if (this.requiresKbo) {
+      if (requiresKboNumber) {
         identifiers.push(identifierKBO);
       }
       identifiers.push(identifierSharepoint);
@@ -696,7 +696,7 @@ export default class OrganizationsNewController extends Controller {
         method: 'POST',
       });
 
-      if (this.requiresKbo) {
+      if (requiresKboNumber) {
         const syncKboData = `/kbo-data-sync/${structuredIdentifierKBO.id}`;
         yield fetch(syncKboData, {
           method: 'POST',

--- a/app/controllers/organizations/organization/core-data/edit.js
+++ b/app/controllers/organizations/organization/core-data/edit.js
@@ -6,6 +6,7 @@ import { action } from '@ember/object';
 import { setEmptyStringsToNull } from 'frontend-organization-portal/utils/empty-string-to-null';
 import isContactEditableOrganization from 'frontend-organization-portal/utils/editable-contact-data';
 import { tracked } from '@glimmer/tracking';
+import requiresKbo from '../../../../helpers/requires-kbo';
 
 export default class OrganizationsOrganizationCoreDataEditController extends Controller {
   @service router;
@@ -21,7 +22,8 @@ export default class OrganizationsOrganizationCoreDataEditController extends Con
       this.model.address.error ||
       this.model.contact.error ||
       this.model.secondaryContact.error ||
-      this.model.identifierKBO.error ||
+      (requiresKbo(this.model.organization) &&
+        this.model.identifierKBO?.error) ||
       this.model.identifierSharepoint.error
     );
   }
@@ -78,9 +80,14 @@ export default class OrganizationsOrganizationCoreDataEditController extends Con
 
     yield Promise.all([
       organization.validate({ relaxMandatoryFoundingOrganization: true }),
-      identifierKBO.validate(),
       identifierSharepoint.validate(),
     ]);
+
+    const requiresKboNumber = requiresKbo(organization);
+
+    if (requiresKboNumber) {
+      yield identifierKBO.validate();
+    }
 
     if (
       this.features.isEnabled('edit-contact-data') ||
@@ -144,9 +151,13 @@ export default class OrganizationsOrganizationCoreDataEditController extends Con
         }
       }
 
-      structuredIdentifierKBO = setEmptyStringsToNull(structuredIdentifierKBO);
-      yield structuredIdentifierKBO.save();
-      yield identifierKBO.save();
+      if (requiresKboNumber) {
+        structuredIdentifierKBO = setEmptyStringsToNull(
+          structuredIdentifierKBO,
+        );
+        yield structuredIdentifierKBO.save();
+        yield identifierKBO.save();
+      }
 
       // FIXME: If uncommented existing SharePoint identifier is not removed
       // when user removes the value in the form. Commenting it a quick, dirty
@@ -161,10 +172,12 @@ export default class OrganizationsOrganizationCoreDataEditController extends Con
       organization = setEmptyStringsToNull(organization);
       yield organization.save();
 
-      const syncKboData = `/kbo-data-sync/${structuredIdentifierKBO.id}`;
-      yield fetch(syncKboData, {
-        method: 'POST',
-      });
+      if (requiresKboNumber) {
+        const syncKboData = `/kbo-data-sync/${structuredIdentifierKBO.id}`;
+        yield fetch(syncKboData, {
+          method: 'POST',
+        });
+      }
 
       this.router.refresh();
       this.router.transitionTo(

--- a/app/helpers/requires-kbo.js
+++ b/app/helpers/requires-kbo.js
@@ -1,0 +1,6 @@
+export default function requiresKbo(organization) {
+  // ILV and Vervoerregioraad have no KBO number, so KBO is optional for them.
+  return !(
+    organization.isInterlokaleVereniging || organization.isVervoerregioraad
+  );
+}

--- a/app/models/abstract-validation-model.js
+++ b/app/models/abstract-validation-model.js
@@ -101,6 +101,10 @@ export default class AbstractValidationModel extends Model {
     this.rollbackAttributes();
   }
 
+  resetErrors() {
+    this.#resetValidationErrors();
+  }
+
   #resetValidationErrors() {
     this._validationError = undefined;
   }

--- a/app/models/administrative-unit-classification-code.js
+++ b/app/models/administrative-unit-classification-code.js
@@ -136,18 +136,18 @@ export const CLASSIFICATION = {
   INTERLOKALE_VERENIGING: {
     id: '3a2649ef-7345-4d3a-8709-f89fc9b44f58',
     label: 'Interlokale vereniging',
-    organizationType: ORGANIZATION_TYPES.ADMINISTRATIVE_UNIT,
+    organizationType: ORGANIZATION_TYPES.PARTNERSHIP,
   },
   VERVOERREGIORAAD: {
     id: 'b2133b86-24f0-44f0-9d10-5b4c7f944a9d',
     label: 'Vervoerregioraad',
-    organizationType: ORGANIZATION_TYPES.ADMINISTRATIVE_UNIT,
+    organizationType: ORGANIZATION_TYPES.PARTNERSHIP,
   },
   ZORGRAAD: {
     // FIXME this is not an administrative unit
     id: '8392b885-a875-4b0d-b6a2-b52e53bda454',
     label: 'Zorgraad',
-    organizationType: ORGANIZATION_TYPES.ASSOCIATION,
+    organizationType: ORGANIZATION_TYPES.PARTNERSHIP,
   },
   BOSGROEP: {
     // FIXME this is not an administrative unit

--- a/app/models/administrative-unit-classification-code.js
+++ b/app/models/administrative-unit-classification-code.js
@@ -133,6 +133,34 @@ export const CLASSIFICATION = {
     label: 'Vlaamse gemeenschapscommissie',
     organizationType: ORGANIZATION_TYPES.ADMINISTRATIVE_UNIT,
   },
+  INTERLOKALE_VERENIGING: {
+    id: '3a2649ef-7345-4d3a-8709-f89fc9b44f58',
+    label: 'Interlokale vereniging',
+    organizationType: ORGANIZATION_TYPES.ADMINISTRATIVE_UNIT,
+  },
+  VERVOERREGIORAAD: {
+    id: 'b2133b86-24f0-44f0-9d10-5b4c7f944a9d',
+    label: 'Vervoerregioraad',
+    organizationType: ORGANIZATION_TYPES.ADMINISTRATIVE_UNIT,
+  },
+  ZORGRAAD: {
+    // FIXME this is not an administrative unit
+    id: '8392b885-a875-4b0d-b6a2-b52e53bda454',
+    label: 'Zorgraad',
+    organizationType: ORGANIZATION_TYPES.ASSOCIATION,
+  },
+  BOSGROEP: {
+    // FIXME this is not an administrative unit
+    id: 'b22948f9-e695-4f24-a530-b6bf3af3b37f',
+    label: 'Bosgroep',
+    organizationType: ORGANIZATION_TYPES.ASSOCIATION,
+  },
+  WOONMAATSCHAPPIJ: {
+    // FIXME this is not an administrative unit
+    id: 'f4e5bb57-1007-4397-828b-b34bbf1e760d',
+    label: 'Woonmaatschappij',
+    organizationType: ORGANIZATION_TYPES.CORPORATION,
+  },
 };
 
 export default class AdministrativeUnitClassificationCodeModel extends OrganizationClassificationCodeModel {}

--- a/app/models/administrative-unit.js
+++ b/app/models/administrative-unit.js
@@ -23,6 +23,8 @@ import {
   PevaProvinceCodeList,
   WorshipServiceCodeList,
   VlaamseGemeenschapscommissieCodeList,
+  InterlokaleVerenigingCodeList,
+  VervoerregioraadCodeList,
 } from '../constants/Classification';
 import {
   allowedFoundingMemberships,
@@ -164,6 +166,14 @@ export default class AdministrativeUnitModel extends OrganizationModel {
     return this._hasClassificationId(VlaamseGemeenschapscommissieCodeList);
   }
 
+  get isInterlokaleVereniging() {
+    return this._hasClassificationId(InterlokaleVerenigingCodeList);
+  }
+
+  get isVervoerregioraad() {
+    return this._hasClassificationId(VervoerregioraadCodeList);
+  }
+
   get isAdministrativeUnit() {
     return true;
   }
@@ -181,7 +191,9 @@ export default class AdministrativeUnitModel extends OrganizationModel {
       this.isApb ||
       this.isPoliceZone ||
       this.isAssistanceZone ||
-      this.isOcmwAssociation
+      this.isOcmwAssociation ||
+      this.isVervoerregioraad ||
+      this.isInterlokaleVereniging
     );
   }
 
@@ -208,7 +220,8 @@ export default class AdministrativeUnitModel extends OrganizationModel {
       this.isPevaMunicipality ||
       this.isPevaProvince ||
       this.isRepresentativeBody ||
-      this.isVlaamseGemeenschapscommissie
+      this.isVlaamseGemeenschapscommissie ||
+      this.isInterlokaleVereniging
     );
   }
 
@@ -221,7 +234,8 @@ export default class AdministrativeUnitModel extends OrganizationModel {
       this.isPevaMunicipality ||
       this.isPevaProvince ||
       this.isRepresentativeBody ||
-      this.isVlaamseGemeenschapscommissie
+      this.isVlaamseGemeenschapscommissie ||
+      this.isInterlokaleVereniging
     );
   }
 

--- a/app/models/organization-classification-code.js
+++ b/app/models/organization-classification-code.js
@@ -1,4 +1,11 @@
 import Model, { attr } from '@ember-data/model';
 export default class OrganizationClassificationCodeModel extends Model {
   @attr label;
+  @attr altLabel;
+
+  // Combined label so the type picker can match on the colloquial werkingsgebied
+  // term as well (e.g. typing "eerstelijnszone" finds "Zorgraad").
+  get searchLabel() {
+    return this.altLabel ? `${this.label} ${this.altLabel}` : this.label;
+  }
 }

--- a/app/models/registered-organization.js
+++ b/app/models/registered-organization.js
@@ -3,19 +3,42 @@ import {
   PrivateOcmwAssociationCodeList,
   CorporationOtherCodeList,
   AssociationOtherCodeList,
+  ZorgraadCodeList,
+  BosgroepCodeList,
+  WoonmaatschappijCodeList,
 } from '../constants/Classification';
 import Joi from 'joi';
 import {
   validateHasManyNotEmptyRequired,
   validateHasManyOptional,
+  validateBelongsToOptional,
+  validateBelongsToRequired,
 } from '../validators/schema';
 import { CLASSIFICATION } from './administrative-unit-classification-code';
 import OrganizationModel from './organization';
+import { belongsTo } from '@ember-data/model';
 
 export default class RegisteredOrganizationModel extends OrganizationModel {
+  // Werkingsgebied (dct:spatial on registered organizations). User-entered.
+  @belongsTo('location', {
+    inverse: null,
+    async: true,
+  })
+  scope;
+
   get validationSchema() {
     const REQUIRED_MESSAGE = 'Selecteer een optie';
     return super.validationSchema.append({
+      // Werkingsgebied: required for the new types that have one, optional for the rest.
+      scope: Joi.when('classification.id', {
+        is: Joi.exist().valid(
+          ...ZorgraadCodeList,
+          ...BosgroepCodeList,
+          ...WoonmaatschappijCodeList,
+        ),
+        then: validateBelongsToRequired(REQUIRED_MESSAGE),
+        otherwise: validateBelongsToOptional(),
+      }),
       // NOTE: The requested functionality was to *not* validate memberships of
       // already existing organizations.
       // 1. For existing organizations: memberships are not validated (optional).
@@ -30,6 +53,9 @@ export default class RegisteredOrganizationModel extends OrganizationModel {
           is: Joi.exist().valid(
             ...CorporationOtherCodeList,
             ...AssociationOtherCodeList,
+            ...ZorgraadCodeList,
+            ...BosgroepCodeList,
+            ...WoonmaatschappijCodeList,
           ),
           then: validateHasManyOptional(),
           otherwise: validateHasManyNotEmptyRequired(REQUIRED_MESSAGE),
@@ -57,6 +83,18 @@ export default class RegisteredOrganizationModel extends OrganizationModel {
 
   get isCorporationOther() {
     return this._hasClassificationId(CorporationOtherCodeList);
+  }
+
+  get isZorgraad() {
+    return this._hasClassificationId(ZorgraadCodeList);
+  }
+
+  get isBosgroep() {
+    return this._hasClassificationId(BosgroepCodeList);
+  }
+
+  get isWoonmaatschappij() {
+    return this._hasClassificationId(WoonmaatschappijCodeList);
   }
 
   get participantClassifications() {

--- a/app/routes/organizations/index.js
+++ b/app/routes/organizations/index.js
@@ -37,7 +37,9 @@ export default class OrganizationsIndexRoute extends Route {
       let filterType = 'phrase_prefix';
       let name = params.name.trim();
 
-      filter[`:${filterType}:legal_name,alternative_name,name`] = name;
+      filter[
+        `:${filterType}:legal_name,alternative_name,name,classification_alternative_name`
+      ] = name;
     }
 
     if (params.identifier) {

--- a/app/routes/organizations/organization/core-data/edit.js
+++ b/app/routes/organizations/organization/core-data/edit.js
@@ -68,7 +68,8 @@ export default class OrganizationsOrganizationCoreDataEditRoute extends Route {
     let identifierKBO = identifiers.find(
       ({ idName }) => idName === ID_NAME.KBO,
     );
-    let structuredIdentifierKBO = await identifierKBO.structuredIdentifier;
+    // Not all organization types have a KBO so identifierKBO can be undefined.
+    let structuredIdentifierKBO = await identifierKBO?.structuredIdentifier;
 
     let identifierSharepoint = identifiers.find(
       ({ idName }) => idName === ID_NAME.SHAREPOINT,

--- a/app/templates/organizations/new.hbs
+++ b/app/templates/organizations/new.hbs
@@ -193,7 +193,14 @@
                 </:content>
               </Item>
             {{/if}}
-            {{#if this.currentOrganizationModel.isAdministrativeUnit}}
+            {{#if
+              (or
+                this.currentOrganizationModel.isAdministrativeUnit
+                this.currentOrganizationModel.isZorgraad
+                this.currentOrganizationModel.isBosgroep
+                this.currentOrganizationModel.isWoonmaatschappij
+              )
+            }}
               <Item
                 @labelFor="scope"
                 @required={{true}}
@@ -259,7 +266,7 @@
             <Item
               @labelFor="kbo-identifier"
               @errorMessage={{@model.identifierKBO.error.structuredIdentifier}}
-              @required={{true}}
+              @required={{this.requiresKbo}}
             >
               <:label>{{@model.identifierKBO.idName}}</:label>
               <:content as |hasError|>

--- a/app/templates/organizations/new.hbs
+++ b/app/templates/organizations/new.hbs
@@ -265,7 +265,12 @@
                 />
               </:content>
             </Item>
-            {{#if (and this.currentOrganizationModel.classification this.requiresKbo)}}
+            {{#if
+              (and
+                this.currentOrganizationModel.classification
+                (requires-kbo this.currentOrganizationModel)
+              )
+            }}
               <Item
                 @labelFor="kbo-identifier"
                 @errorMessage={{@model.identifierKBO.error.structuredIdentifier}}

--- a/app/templates/organizations/new.hbs
+++ b/app/templates/organizations/new.hbs
@@ -350,8 +350,17 @@
     {{#if
       (and
         this.currentOrganizationModel.classification
-        (not this.currentOrganizationModel.isAssociationOther)
-        (not this.currentOrganizationModel.isCorporationOther)
+        (or
+          this.currentOrganizationModel.isAgb
+          this.currentOrganizationModel.isDistrict
+          this.currentOrganizationModel.isIgs
+          this.currentOrganizationModel.isPoliceZone
+          this.currentOrganizationModel.isAssistanceZone
+          this.currentOrganizationModel.isOcmwAssociation
+          this.currentOrganizationModel.isPevaMunicipality
+          this.currentOrganizationModel.isPevaProvince
+          this.currentOrganizationModel.isApb
+        )
       )
     }}
       <EditCard @containsRequiredFields={{true}}>
@@ -507,8 +516,7 @@
                         />
                       </:content>
                     </Item>
-                  {{else}}
-                    {{! Only APBs remain here }}
+                  {{else if this.currentOrganizationModel.isApb}}
                     <Item
                       @labelFor="related-province"
                       @required={{true}}

--- a/app/templates/organizations/new.hbs
+++ b/app/templates/organizations/new.hbs
@@ -107,10 +107,12 @@
                 />
               </:content>
             </Item>
-            {{#if (and
-                    this.currentOrganizationModel.classification
-                    (not this.currentOrganizationModel.isWorshipAdministrativeUnit)
-                  )}}
+            {{#if
+              (and
+                this.currentOrganizationModel.classification
+                (not this.currentOrganizationModel.isWorshipAdministrativeUnit)
+              )
+            }}
               <Item
                 @labelFor="legal-form-select"
                 @required={{true}}
@@ -263,31 +265,33 @@
                 />
               </:content>
             </Item>
-            <Item
-              @labelFor="kbo-identifier"
-              @errorMessage={{@model.identifierKBO.error.structuredIdentifier}}
-              @required={{this.requiresKbo}}
-            >
-              <:label>{{@model.identifierKBO.idName}}</:label>
-              <:content as |hasError|>
-                <AuInput
-                  @width="block"
-                  @error={{hasError}}
-                  autocomplete="off"
-                  value={{@model.structuredIdentifierKBO.localId}}
-                  id="kbo-identifier"
-                  class="au-c-input--mask"
-                  placeholder="____.___.___"
-                  {{au-inputmask
-                    options=(hash mask="####.###.###" placeholder="_")
-                  }}
-                  {{on "input" this.setKbo}}
-                />
-              </:content>
-              <:error as |error|>
-                <Error::KboNumber @error={{error}} />
-              </:error>
-            </Item>
+            {{#if (and this.currentOrganizationModel.classification this.requiresKbo)}}
+              <Item
+                @labelFor="kbo-identifier"
+                @errorMessage={{@model.identifierKBO.error.structuredIdentifier}}
+                @required={{true}}
+              >
+                <:label>{{@model.identifierKBO.idName}}</:label>
+                <:content as |hasError|>
+                  <AuInput
+                    @width="block"
+                    @error={{hasError}}
+                    autocomplete="off"
+                    value={{@model.structuredIdentifierKBO.localId}}
+                    id="kbo-identifier"
+                    class="au-c-input--mask"
+                    placeholder="____.___.___"
+                    {{au-inputmask
+                      options=(hash mask="####.###.###" placeholder="_")
+                    }}
+                    {{on "input" this.setKbo}}
+                  />
+                </:content>
+                <:error as |error|>
+                  <Error::KboNumber @error={{error}} />
+                </:error>
+              </Item>
+            {{/if}}
             <Item
               @labelFor="sharepoint-identifier"
               @errorMessage={{@model.identifierSharepoint.error.structuredIdentifier.message}}

--- a/app/templates/organizations/organization/core-data/edit.hbs
+++ b/app/templates/organizations/organization/core-data/edit.hbs
@@ -122,7 +122,9 @@
                       <LegalFormSelect
                         @selected={{@model.organization.legalForm}}
                         @onChange={{fn (mut @model.organization.legalForm)}}
-                        @disabled={{not (is-feature-enabled "legal-form-editable")}}
+                        @disabled={{not
+                          (is-feature-enabled "legal-form-editable")
+                        }}
                         @error={{hasError}}
                         @triggerId="legal-form"
                         @id="legal-form-select"
@@ -256,31 +258,33 @@
                     </PowerSelect>
                   </:content>
                 </Item>
-                <Item
-                  @labelFor="kbo-identifier"
-                  @errorMessage={{@model.identifierKBO.error.structuredIdentifier}}
-                  @required={{true}}
-                >
-                  <:label>{{@model.identifierKBO.idName}}</:label>
-                  <:content as |hasError|>
-                    <AuInput
-                      @width="block"
-                      @error={{hasError}}
-                      autocomplete="off"
-                      value={{@model.structuredIdentifierKBO.localId}}
-                      id="kbo-identifier"
-                      class="au-c-input--mask"
-                      placeholder="____.___.___"
-                      {{au-inputmask
-                        options=(hash mask="####.###.###" placeholder="_")
-                      }}
-                      {{on "input" this.setKbo}}
-                    />
-                  </:content>
-                  <:error as |error|>
-                    <Error::KboNumber @error={{error}} />
-                  </:error>
-                </Item>
+                {{#if (requires-kbo @model.organization)}}
+                  <Item
+                    @labelFor="kbo-identifier"
+                    @errorMessage={{@model.identifierKBO.error.structuredIdentifier}}
+                    @required={{true}}
+                  >
+                    <:label>{{@model.identifierKBO.idName}}</:label>
+                    <:content as |hasError|>
+                      <AuInput
+                        @width="block"
+                        @error={{hasError}}
+                        autocomplete="off"
+                        value={{@model.structuredIdentifierKBO.localId}}
+                        id="kbo-identifier"
+                        class="au-c-input--mask"
+                        placeholder="____.___.___"
+                        {{au-inputmask
+                          options=(hash mask="####.###.###" placeholder="_")
+                        }}
+                        {{on "input" this.setKbo}}
+                      />
+                    </:content>
+                    <:error as |error|>
+                      <Error::KboNumber @error={{error}} />
+                    </:error>
+                  </Item>
+                {{/if}}
                 <Item
                   @labelFor="sharepoint-identifier"
                   @errorMessage={{@model.identifierSharepoint.error.structuredIdentifier.message}}

--- a/app/utils/group-classifications.js
+++ b/app/utils/group-classifications.js
@@ -24,6 +24,7 @@ export function convertClassificationToGroups(codes) {
     ),
     createGroup('Verenigingen', ORGANIZATION_TYPES.ASSOCIATION, codes),
     createGroup('Vennootschappen', ORGANIZATION_TYPES.CORPORATION, codes),
+    createGroup('Samenwerkingsverband', ORGANIZATION_TYPES.PARTNERSHIP, codes),
   ].filter((group) => group.options.length > 0);
 }
 


### PR DESCRIPTION
@Windvis cf https://github.com/lblod/app-organization-portal/pull/605

I've drafted some front end changes
- classifications have an altlabel (vervoerregio is used instead of vervoerregioraad )
- optional KBO - ILV and vervoerregioraad are not formal orgs

werkingsgebied for non bestuursorganen is different at RDF level, but mapped to the same scope in the resource config