### PR TITLE
OP-3840: added worship services to the related organizations conditional

### DIFF
--- a/app/templates/organizations/new.hbs
+++ b/app/templates/organizations/new.hbs
@@ -360,6 +360,7 @@
           this.currentOrganizationModel.isPevaMunicipality
           this.currentOrganizationModel.isPevaProvince
           this.currentOrganizationModel.isApb
+          this.currentOrganizationModel.isWorshipAdministrativeUnit
         )
       )
     }}


### PR DESCRIPTION
A change in OP-3794 (https://github.com/lblod/frontend-organization-portal/pull/710/changes#diff-8387983ed7c6f3ba54175cd7bbc0a3f81f6316c30ca48bd013f33051139355d9R354) leads to the related organization component not being shown for worship services. Because of the validation on this field, a worship service could not be created anymore.

Fixed this by adding worship services to the conditional.

TO TEST:
- rsync dev data
- build this PR and add to OP docker-compose
- try creating a new worship service