### PR TITLE
[OP-3844] Add Regionaal zorgplatform and Andere organization types

### DIFF
--- a/app/constants/Classification.js
+++ b/app/constants/Classification.js
@@ -52,8 +52,7 @@ export const PevaCodeList = [
   ...PevaProvinceCodeList,
 ];
 
-export const AssociationOtherCodeList = [CLASSIFICATION.ASSOCIATION_OTHER.id];
-export const CorporationOtherCodeList = [CLASSIFICATION.CORPORATION_OTHER.id];
+export const AndereCodeList = [CLASSIFICATION.ANDERE.id];
 
 export const VlaamseGemeenschapscommissieCodeList = [
   CLASSIFICATION.VLAAMSE_GEMEENSCHAPSCOMMISSIE.id,
@@ -64,5 +63,8 @@ export const InterlokaleVerenigingCodeList = [
 ];
 export const VervoerregioraadCodeList = [CLASSIFICATION.VERVOERREGIORAAD.id];
 export const ZorgraadCodeList = [CLASSIFICATION.ZORGRAAD.id];
+export const RegionaalZorgplatformCodeList = [
+  CLASSIFICATION.REGIONAAL_ZORGPLATFORM.id,
+];
 export const BosgroepCodeList = [CLASSIFICATION.BOSGROEP.id];
 export const WoonmaatschappijCodeList = [CLASSIFICATION.WOONMAATSCHAPPIJ.id];

--- a/app/constants/memberships.js
+++ b/app/constants/memberships.js
@@ -1,11 +1,10 @@
 import { MEMBERSHIP_ROLES_MAPPING } from 'frontend-organization-portal/models/membership-role';
 import {
   AgbCodeList,
+  AndereCodeList,
   ApbCodeList,
   AssistanceZoneCodeList,
-  AssociationOtherCodeList,
   CentralWorshipServiceCodeList,
-  CorporationOtherCodeList,
   DistrictCodeList,
   IGSCodeList,
   MunicipalityCodeList,
@@ -46,8 +45,7 @@ export const allowedParticipationMemberships = [
       ...AssistanceZoneCodeList,
       ...PevaCodeList,
       ...OcmwAssociationCodeList,
-      ...AssociationOtherCodeList,
-      ...CorporationOtherCodeList,
+      ...AndereCodeList,
     ],
   },
   {
@@ -56,8 +54,7 @@ export const allowedParticipationMemberships = [
       ...OcmwAssociationCodeList,
       ...MunicipalityCodeList,
       ...OCMWCodeList,
-      ...AssociationOtherCodeList,
-      ...CorporationOtherCodeList,
+      ...AndereCodeList,
     ],
   },
   {
@@ -96,16 +93,14 @@ export const allowedFoundingMemberships = [
     organizations: [...PevaMunicipalityCodeList],
     members: [
       ...MunicipalityCodeList,
-      ...AssociationOtherCodeList,
-      ...CorporationOtherCodeList,
+      ...AndereCodeList,
     ],
   },
   {
     organizations: [...PevaProvinceCodeList],
     members: [
       ...ProvinceCodeList,
-      ...AssociationOtherCodeList,
-      ...CorporationOtherCodeList,
+      ...AndereCodeList,
     ],
   },
   {
@@ -114,8 +109,7 @@ export const allowedFoundingMemberships = [
       ...OcmwAssociationCodeList,
       ...MunicipalityCodeList,
       ...OCMWCodeList,
-      ...AssociationOtherCodeList,
-      ...CorporationOtherCodeList,
+      ...AndereCodeList,
     ],
   },
 ];

--- a/app/constants/memberships.js
+++ b/app/constants/memberships.js
@@ -91,17 +91,11 @@ export const allowedFoundingMemberships = [
   },
   {
     organizations: [...PevaMunicipalityCodeList],
-    members: [
-      ...MunicipalityCodeList,
-      ...AndereCodeList,
-    ],
+    members: [...MunicipalityCodeList, ...AndereCodeList],
   },
   {
     organizations: [...PevaProvinceCodeList],
-    members: [
-      ...ProvinceCodeList,
-      ...AndereCodeList,
-    ],
+    members: [...ProvinceCodeList, ...AndereCodeList],
   },
   {
     organizations: [...OcmwAssociationCodeList],

--- a/app/constants/organization-types.js
+++ b/app/constants/organization-types.js
@@ -3,4 +3,5 @@ export const ORGANIZATION_TYPES = Object.freeze({
   ASSOCIATION: 'Vereniging',
   CORPORATION: 'Vennootschap',
   PARTNERSHIP: 'Samenwerkingsverband',
+  OTHER: 'Andere',
 });

--- a/app/controllers/organizations/new.js
+++ b/app/controllers/organizations/new.js
@@ -373,11 +373,11 @@ export default class OrganizationsNewController extends Controller {
         CLASSIFICATION.VERENIGING_OF_VENNOOTSCHAP_VOOR_SOCIALE_DIENSTVERLENING
           .id,
         CLASSIFICATION.WOONZORGVERENIGING_OF_WOONZORGVENNOOTSCHAP.id,
-        CLASSIFICATION.ASSOCIATION_OTHER.id,
-        CLASSIFICATION.CORPORATION_OTHER.id,
         CLASSIFICATION.ZORGRAAD.id,
+        CLASSIFICATION.REGIONAAL_ZORGPLATFORM.id,
         CLASSIFICATION.BOSGROEP.id,
         CLASSIFICATION.WOONMAATSCHAPPIJ.id,
+        CLASSIFICATION.ANDERE.id,
       ].includes(classificationCodeId)
     ) {
       return this.store.createRecord('registered-organization');
@@ -664,8 +664,7 @@ export default class OrganizationsNewController extends Controller {
           this.currentOrganizationModel.isOcmwAssociation ||
           this.currentOrganizationModel.isPevaMunicipality ||
           this.currentOrganizationModel.isPevaProvince ||
-          this.currentOrganizationModel.isAssociationOther ||
-          this.currentOrganizationModel.isCorporationOther
+          this.currentOrganizationModel.isAndere
         ) {
           const siteTypes = yield this.store.findAll('site-type');
           primarySite.siteType = siteTypes.find(

--- a/app/models/administrative-unit-classification-code.js
+++ b/app/models/administrative-unit-classification-code.js
@@ -106,18 +106,6 @@ export const CLASSIFICATION = {
     label: 'Woonzorgvereniging of woonzorgvennootschap',
     organizationType: ORGANIZATION_TYPES.ASSOCIATION,
   },
-  ASSOCIATION_OTHER: {
-    // FIXME this is not an administrative unit
-    id: '3e5c8e30-95a7-47b0-b0a4-210d5bd440a7',
-    label: 'Ander type vereniging',
-    organizationType: ORGANIZATION_TYPES.ASSOCIATION,
-  },
-  CORPORATION_OTHER: {
-    // FIXME this is not an administrative unit
-    id: 'b9ed22af-3661-4c3e-b07f-b641d80ebf61',
-    label: 'Vennootschap',
-    organizationType: ORGANIZATION_TYPES.CORPORATION,
-  },
   PEVA_MUNICIPALITY: {
     id: '2ad46df5-5c79-4d67-84d5-604c1377231e',
     label: 'PEVA gemeente',
@@ -149,6 +137,12 @@ export const CLASSIFICATION = {
     label: 'Zorgraad',
     organizationType: ORGANIZATION_TYPES.PARTNERSHIP,
   },
+  REGIONAAL_ZORGPLATFORM: {
+    // FIXME this is not an administrative unit
+    id: 'e3afe092-6ca6-4685-94c6-1ee20811efc4',
+    label: 'Regionaal zorgplatform',
+    organizationType: ORGANIZATION_TYPES.PARTNERSHIP,
+  },
   BOSGROEP: {
     // FIXME this is not an administrative unit
     id: 'b22948f9-e695-4f24-a530-b6bf3af3b37f',
@@ -160,6 +154,12 @@ export const CLASSIFICATION = {
     id: 'f4e5bb57-1007-4397-828b-b34bbf1e760d',
     label: 'Woonmaatschappij',
     organizationType: ORGANIZATION_TYPES.CORPORATION,
+  },
+  ANDERE: {
+    // FIXME this is not an administrative unit
+    id: '7a199d27-31c3-44bb-a58f-b3a64673a8b6',
+    label: 'Andere',
+    organizationType: ORGANIZATION_TYPES.OTHER,
   },
 };
 

--- a/app/models/registered-organization.js
+++ b/app/models/registered-organization.js
@@ -1,9 +1,9 @@
 import {
   OcmwAssociationCodeList,
   PrivateOcmwAssociationCodeList,
-  CorporationOtherCodeList,
-  AssociationOtherCodeList,
+  AndereCodeList,
   ZorgraadCodeList,
+  RegionaalZorgplatformCodeList,
   BosgroepCodeList,
   WoonmaatschappijCodeList,
 } from '../constants/Classification';
@@ -33,6 +33,7 @@ export default class RegisteredOrganizationModel extends OrganizationModel {
       scope: Joi.when('classification.id', {
         is: Joi.exist().valid(
           ...ZorgraadCodeList,
+          ...RegionaalZorgplatformCodeList,
           ...BosgroepCodeList,
           ...WoonmaatschappijCodeList,
           ...PrivateOcmwAssociationCodeList,
@@ -52,9 +53,9 @@ export default class RegisteredOrganizationModel extends OrganizationModel {
         is: Joi.exist().valid(true),
         then: Joi.when('classification.id', {
           is: Joi.exist().valid(
-            ...CorporationOtherCodeList,
-            ...AssociationOtherCodeList,
+            ...AndereCodeList,
             ...ZorgraadCodeList,
+            ...RegionaalZorgplatformCodeList,
             ...BosgroepCodeList,
             ...WoonmaatschappijCodeList,
           ),
@@ -78,16 +79,16 @@ export default class RegisteredOrganizationModel extends OrganizationModel {
     return this._hasClassificationId(PrivateOcmwAssociationCodeList);
   }
 
-  get isAssociationOther() {
-    return this._hasClassificationId(AssociationOtherCodeList);
-  }
-
-  get isCorporationOther() {
-    return this._hasClassificationId(CorporationOtherCodeList);
+  get isAndere() {
+    return this._hasClassificationId(AndereCodeList);
   }
 
   get isZorgraad() {
     return this._hasClassificationId(ZorgraadCodeList);
+  }
+
+  get isRegionaalZorgplatform() {
+    return this._hasClassificationId(RegionaalZorgplatformCodeList);
   }
 
   get isBosgroep() {
@@ -103,8 +104,7 @@ export default class RegisteredOrganizationModel extends OrganizationModel {
       return OcmwAssociationCodeList.concat([
         CLASSIFICATION.MUNICIPALITY.id,
         CLASSIFICATION.OCMW.id,
-        CLASSIFICATION.ASSOCIATION_OTHER.id,
-        CLASSIFICATION.CORPORATION_OTHER.id,
+        CLASSIFICATION.ANDERE.id,
       ]);
     }
     return [];
@@ -115,8 +115,7 @@ export default class RegisteredOrganizationModel extends OrganizationModel {
       return OcmwAssociationCodeList.concat([
         CLASSIFICATION.MUNICIPALITY.id,
         CLASSIFICATION.OCMW.id,
-        CLASSIFICATION.ASSOCIATION_OTHER.id,
-        CLASSIFICATION.CORPORATION_OTHER.id,
+        CLASSIFICATION.ANDERE.id,
       ]);
     }
     return [];

--- a/app/templates/organizations/new.hbs
+++ b/app/templates/organizations/new.hbs
@@ -219,6 +219,7 @@
               (or
                 this.currentOrganizationModel.isAdministrativeUnit
                 this.currentOrganizationModel.isZorgraad
+                this.currentOrganizationModel.isRegionaalZorgplatform
                 this.currentOrganizationModel.isBosgroep
                 this.currentOrganizationModel.isWoonmaatschappij
                 this.currentOrganizationModel.isPrivateOcmwAssociation

--- a/app/templates/organizations/organization/core-data/edit.hbs
+++ b/app/templates/organizations/organization/core-data/edit.hbs
@@ -214,6 +214,7 @@
                   (or
                     @model.organization.isAdministrativeUnit
                     @model.organization.isZorgraad
+                    @model.organization.isRegionaalZorgplatform
                     @model.organization.isBosgroep
                     @model.organization.isWoonmaatschappij
                     @model.organization.isPrivateOcmwAssociation

--- a/app/templates/organizations/organization/core-data/index.hbs
+++ b/app/templates/organizations/organization/core-data/index.hbs
@@ -160,6 +160,7 @@
                 (or
                   @model.organization.isAdministrativeUnit
                   @model.organization.isZorgraad
+                  @model.organization.isRegionaalZorgplatform
                   @model.organization.isBosgroep
                   @model.organization.isWoonmaatschappij
                   @model.organization.isPrivateOcmwAssociation

--- a/app/templates/organizations/organization/related-organizations/index.hbs
+++ b/app/templates/organizations/organization/related-organizations/index.hbs
@@ -12,8 +12,7 @@
               @model.organization.isDistrict
               @model.organization.isProvince
               @model.organization.isRepresentativeBody
-              @model.organization.isAssociationOther
-              @model.organization.isCorporationOther
+              @model.organization.isAndere
             )
           )
         }}

--- a/app/utils/editable-contact-data.js
+++ b/app/utils/editable-contact-data.js
@@ -7,9 +7,5 @@
  * @returns {boolean} true if address and contact data should be editable
  */
 export default function isContactEditableOrganization(organization) {
-  return (
-    organization.isPrivateOcmwAssociation ||
-    organization.isAssociationOther ||
-    organization.isCorporationOther
-  );
+  return organization.isPrivateOcmwAssociation || organization.isAndere;
 }

--- a/app/utils/group-classifications.js
+++ b/app/utils/group-classifications.js
@@ -25,6 +25,7 @@ export function convertClassificationToGroups(codes) {
     createGroup('Verenigingen', ORGANIZATION_TYPES.ASSOCIATION, codes),
     createGroup('Vennootschappen', ORGANIZATION_TYPES.CORPORATION, codes),
     createGroup('Samenwerkingsverband', ORGANIZATION_TYPES.PARTNERSHIP, codes),
+    createGroup('Andere', ORGANIZATION_TYPES.OTHER, codes),
   ].filter((group) => group.options.length > 0);
 }
 

--- a/tests/unit/models/administrative-unit-test.js
+++ b/tests/unit/models/administrative-unit-test.js
@@ -409,17 +409,11 @@ module('Unit | Model | administrative unit', function (hooks) {
       [CLASSIFICATION.AGB, [CLASSIFICATION.MUNICIPALITY.id]],
       [
         CLASSIFICATION.PEVA_MUNICIPALITY,
-        [
-          CLASSIFICATION.MUNICIPALITY.id,
-          CLASSIFICATION.ANDERE.id,
-        ],
+        [CLASSIFICATION.MUNICIPALITY.id, CLASSIFICATION.ANDERE.id],
       ],
       [
         CLASSIFICATION.PEVA_PROVINCE,
-        [
-          CLASSIFICATION.PROVINCE.id,
-          CLASSIFICATION.ANDERE.id,
-        ],
+        [CLASSIFICATION.PROVINCE.id, CLASSIFICATION.ANDERE.id],
       ],
       [
         CLASSIFICATION.WELZIJNSVERENIGING,

--- a/tests/unit/models/administrative-unit-test.js
+++ b/tests/unit/models/administrative-unit-test.js
@@ -356,15 +356,13 @@ module('Unit | Model | administrative unit', function (hooks) {
       CLASSIFICATION.ZIEKENHUISVERENIGING.id,
       CLASSIFICATION.VERENIGING_OF_VENNOOTSCHAP_VOOR_SOCIALE_DIENSTVERLENING.id,
       CLASSIFICATION.WOONZORGVERENIGING_OF_WOONZORGVENNOOTSCHAP.id,
-      CLASSIFICATION.ASSOCIATION_OTHER.id,
-      CLASSIFICATION.CORPORATION_OTHER.id,
+      CLASSIFICATION.ANDERE.id,
     ];
 
     const ocmwAssociationParticipants = OcmwAssociationCodeList.concat([
       CLASSIFICATION.MUNICIPALITY.id,
       CLASSIFICATION.OCMW.id,
-      CLASSIFICATION.ASSOCIATION_OTHER.id,
-      CLASSIFICATION.CORPORATION_OTHER.id,
+      CLASSIFICATION.ANDERE.id,
     ]);
 
     const pevaParticipants = [
@@ -413,16 +411,14 @@ module('Unit | Model | administrative unit', function (hooks) {
         CLASSIFICATION.PEVA_MUNICIPALITY,
         [
           CLASSIFICATION.MUNICIPALITY.id,
-          CLASSIFICATION.ASSOCIATION_OTHER.id,
-          CLASSIFICATION.CORPORATION_OTHER.id,
+          CLASSIFICATION.ANDERE.id,
         ],
       ],
       [
         CLASSIFICATION.PEVA_PROVINCE,
         [
           CLASSIFICATION.PROVINCE.id,
-          CLASSIFICATION.ASSOCIATION_OTHER.id,
-          CLASSIFICATION.CORPORATION_OTHER.id,
+          CLASSIFICATION.ANDERE.id,
         ],
       ],
       [
@@ -431,8 +427,7 @@ module('Unit | Model | administrative unit', function (hooks) {
           ...OcmwAssociationCodeList,
           CLASSIFICATION.MUNICIPALITY.id,
           CLASSIFICATION.OCMW.id,
-          CLASSIFICATION.ASSOCIATION_OTHER.id,
-          CLASSIFICATION.CORPORATION_OTHER.id,
+          CLASSIFICATION.ANDERE.id,
         ],
       ],
       [
@@ -441,8 +436,7 @@ module('Unit | Model | administrative unit', function (hooks) {
           ...OcmwAssociationCodeList,
           CLASSIFICATION.MUNICIPALITY.id,
           CLASSIFICATION.OCMW.id,
-          CLASSIFICATION.ASSOCIATION_OTHER.id,
-          CLASSIFICATION.CORPORATION_OTHER.id,
+          CLASSIFICATION.ANDERE.id,
         ],
       ],
     ].forEach(([cl, classificationCodes]) => {

--- a/tests/unit/models/organization-test.js
+++ b/tests/unit/models/organization-test.js
@@ -281,10 +281,7 @@ module('Unit | Model | organization', function (hooks) {
         CLASSIFICATION.WOONZORGVERENIGING_OF_WOONZORGVENNOOTSCHAP,
         [...IGSCodeList, ...OcmwAssociationCodeList],
       ],
-      [
-        CLASSIFICATION.ANDERE,
-        [...IGSCodeList, ...OcmwAssociationCodeList],
-      ],
+      [CLASSIFICATION.ANDERE, [...IGSCodeList, ...OcmwAssociationCodeList]],
     ].forEach(([cl, classificationCodes]) => {
       test(`it should allow a(n) ${cl.label} to participate in the correct kind of organizations`, async function (assert) {
         const classification = this.store().createRecord(
@@ -315,17 +312,11 @@ module('Unit | Model | organization', function (hooks) {
       [CLASSIFICATION.AGB, [CLASSIFICATION.MUNICIPALITY.id]],
       [
         CLASSIFICATION.PEVA_MUNICIPALITY,
-        [
-          CLASSIFICATION.MUNICIPALITY.id,
-          CLASSIFICATION.ANDERE.id,
-        ],
+        [CLASSIFICATION.MUNICIPALITY.id, CLASSIFICATION.ANDERE.id],
       ],
       [
         CLASSIFICATION.PEVA_PROVINCE,
-        [
-          CLASSIFICATION.PROVINCE.id,
-          CLASSIFICATION.ANDERE.id,
-        ],
+        [CLASSIFICATION.PROVINCE.id, CLASSIFICATION.ANDERE.id],
       ],
       [
         CLASSIFICATION.WELZIJNSVERENIGING,
@@ -411,10 +402,7 @@ module('Unit | Model | organization', function (hooks) {
         [CLASSIFICATION.PEVA_PROVINCE.id, CLASSIFICATION.APB.id],
       ],
       [CLASSIFICATION.OCMW, [...OcmwAssociationCodeList]],
-      [
-        CLASSIFICATION.ANDERE,
-        [...PevaCodeList, ...OcmwAssociationCodeList],
-      ],
+      [CLASSIFICATION.ANDERE, [...PevaCodeList, ...OcmwAssociationCodeList]],
     ].forEach(([cl, classificationCodes]) => {
       test(`it should allow a(n) ${cl.label} to found the correct organizations`, async function (assert) {
         const classification = this.store().createRecord(

--- a/tests/unit/models/organization-test.js
+++ b/tests/unit/models/organization-test.js
@@ -176,15 +176,13 @@ module('Unit | Model | organization', function (hooks) {
       CLASSIFICATION.ZIEKENHUISVERENIGING.id,
       CLASSIFICATION.VERENIGING_OF_VENNOOTSCHAP_VOOR_SOCIALE_DIENSTVERLENING.id,
       CLASSIFICATION.WOONZORGVERENIGING_OF_WOONZORGVENNOOTSCHAP.id,
-      CLASSIFICATION.ASSOCIATION_OTHER.id,
-      CLASSIFICATION.CORPORATION_OTHER.id,
+      CLASSIFICATION.ANDERE.id,
     ];
 
     const ocmwAssociationParticipants = OcmwAssociationCodeList.concat([
       CLASSIFICATION.MUNICIPALITY.id,
       CLASSIFICATION.OCMW.id,
-      CLASSIFICATION.ASSOCIATION_OTHER.id,
-      CLASSIFICATION.CORPORATION_OTHER.id,
+      CLASSIFICATION.ANDERE.id,
     ]);
 
     const pevaParticipants = [
@@ -284,11 +282,7 @@ module('Unit | Model | organization', function (hooks) {
         [...IGSCodeList, ...OcmwAssociationCodeList],
       ],
       [
-        CLASSIFICATION.ASSOCIATION_OTHER,
-        [...IGSCodeList, ...OcmwAssociationCodeList],
-      ],
-      [
-        CLASSIFICATION.CORPORATION_OTHER,
+        CLASSIFICATION.ANDERE,
         [...IGSCodeList, ...OcmwAssociationCodeList],
       ],
     ].forEach(([cl, classificationCodes]) => {
@@ -323,16 +317,14 @@ module('Unit | Model | organization', function (hooks) {
         CLASSIFICATION.PEVA_MUNICIPALITY,
         [
           CLASSIFICATION.MUNICIPALITY.id,
-          CLASSIFICATION.ASSOCIATION_OTHER.id,
-          CLASSIFICATION.CORPORATION_OTHER.id,
+          CLASSIFICATION.ANDERE.id,
         ],
       ],
       [
         CLASSIFICATION.PEVA_PROVINCE,
         [
           CLASSIFICATION.PROVINCE.id,
-          CLASSIFICATION.ASSOCIATION_OTHER.id,
-          CLASSIFICATION.CORPORATION_OTHER.id,
+          CLASSIFICATION.ANDERE.id,
         ],
       ],
       [
@@ -341,8 +333,7 @@ module('Unit | Model | organization', function (hooks) {
           ...OcmwAssociationCodeList,
           CLASSIFICATION.MUNICIPALITY.id,
           CLASSIFICATION.OCMW.id,
-          CLASSIFICATION.ASSOCIATION_OTHER.id,
-          CLASSIFICATION.CORPORATION_OTHER.id,
+          CLASSIFICATION.ANDERE.id,
         ],
       ],
       [
@@ -351,8 +342,7 @@ module('Unit | Model | organization', function (hooks) {
           ...OcmwAssociationCodeList,
           CLASSIFICATION.MUNICIPALITY.id,
           CLASSIFICATION.OCMW.id,
-          CLASSIFICATION.ASSOCIATION_OTHER.id,
-          CLASSIFICATION.CORPORATION_OTHER.id,
+          CLASSIFICATION.ANDERE.id,
         ],
       ],
       [
@@ -361,8 +351,7 @@ module('Unit | Model | organization', function (hooks) {
           ...OcmwAssociationCodeList,
           CLASSIFICATION.MUNICIPALITY.id,
           CLASSIFICATION.OCMW.id,
-          CLASSIFICATION.ASSOCIATION_OTHER.id,
-          CLASSIFICATION.CORPORATION_OTHER.id,
+          CLASSIFICATION.ANDERE.id,
         ],
       ],
       [
@@ -371,8 +360,7 @@ module('Unit | Model | organization', function (hooks) {
           ...OcmwAssociationCodeList,
           CLASSIFICATION.MUNICIPALITY.id,
           CLASSIFICATION.OCMW.id,
-          CLASSIFICATION.ASSOCIATION_OTHER.id,
-          CLASSIFICATION.CORPORATION_OTHER.id,
+          CLASSIFICATION.ANDERE.id,
         ],
       ],
       [
@@ -381,8 +369,7 @@ module('Unit | Model | organization', function (hooks) {
           ...OcmwAssociationCodeList,
           CLASSIFICATION.MUNICIPALITY.id,
           CLASSIFICATION.OCMW.id,
-          CLASSIFICATION.ASSOCIATION_OTHER.id,
-          CLASSIFICATION.CORPORATION_OTHER.id,
+          CLASSIFICATION.ANDERE.id,
         ],
       ],
     ].forEach(([cl, classificationCodes]) => {
@@ -425,11 +412,7 @@ module('Unit | Model | organization', function (hooks) {
       ],
       [CLASSIFICATION.OCMW, [...OcmwAssociationCodeList]],
       [
-        CLASSIFICATION.ASSOCIATION_OTHER,
-        [...PevaCodeList, ...OcmwAssociationCodeList],
-      ],
-      [
-        CLASSIFICATION.CORPORATION_OTHER,
+        CLASSIFICATION.ANDERE,
         [...PevaCodeList, ...OcmwAssociationCodeList],
       ],
     ].forEach(([cl, classificationCodes]) => {

--- a/tests/unit/models/registered-organization-test.js
+++ b/tests/unit/models/registered-organization-test.js
@@ -42,10 +42,7 @@ module('Unit | Model | registered organization', function (hooks) {
       });
     });
 
-    [
-      CLASSIFICATION.ASSOCIATION_OTHER,
-      CLASSIFICATION.CORPORATION_OTHER,
-    ].forEach((cl) => {
+    [CLASSIFICATION.ANDERE].forEach((cl) => {
       test(`it should not return an extra error creating an empty ${cl.label} model`, async function (assert) {
         const classification = this.store().createRecord(
           'registered-organization-classification-code',

--- a/tests/unit/utils/classification-identifiers-test.js
+++ b/tests/unit/utils/classification-identifiers-test.js
@@ -248,9 +248,7 @@ module('Unit | Utility | classification-identifiers', function (hooks) {
             ORGANIZATION_TYPES.CORPORATION,
           );
 
-          assert.deepEqual(result.sort(), [
-            CLASSIFICATION.WOONMAATSCHAPPIJ.id,
-          ]);
+          assert.deepEqual(result.sort(), [CLASSIFICATION.WOONMAATSCHAPPIJ.id]);
         });
 
         test('it should return all non-worship other classification code identifiers', async function (assert) {

--- a/tests/unit/utils/classification-identifiers-test.js
+++ b/tests/unit/utils/classification-identifiers-test.js
@@ -209,8 +209,13 @@ module('Unit | Utility | classification-identifiers', function (hooks) {
                       .id,
                     CLASSIFICATION.WOONZORGVERENIGING_OF_WOONZORGVENNOOTSCHAP
                       .id,
-                    CLASSIFICATION.ASSOCIATION_OTHER.id,
-                    CLASSIFICATION.CORPORATION_OTHER.id,
+                    CLASSIFICATION.BOSGROEP.id,
+                    CLASSIFICATION.WOONMAATSCHAPPIJ.id,
+                    CLASSIFICATION.INTERLOKALE_VERENIGING.id,
+                    CLASSIFICATION.VERVOERREGIORAAD.id,
+                    CLASSIFICATION.ZORGRAAD.id,
+                    CLASSIFICATION.REGIONAAL_ZORGPLATFORM.id,
+                    CLASSIFICATION.ANDERE.id,
                   ].includes(id),
               )
               .sort(),
@@ -231,7 +236,7 @@ module('Unit | Utility | classification-identifiers', function (hooks) {
               CLASSIFICATION
                 .VERENIGING_OF_VENNOOTSCHAP_VOOR_SOCIALE_DIENSTVERLENING.id,
               CLASSIFICATION.WOONZORGVERENIGING_OF_WOONZORGVENNOOTSCHAP.id,
-              CLASSIFICATION.ASSOCIATION_OTHER.id,
+              CLASSIFICATION.BOSGROEP.id,
             ].sort(),
           );
         });
@@ -244,8 +249,18 @@ module('Unit | Utility | classification-identifiers', function (hooks) {
           );
 
           assert.deepEqual(result.sort(), [
-            CLASSIFICATION.CORPORATION_OTHER.id,
+            CLASSIFICATION.WOONMAATSCHAPPIJ.id,
           ]);
+        });
+
+        test('it should return all non-worship other classification code identifiers', async function (assert) {
+          let result = getClassificationIdsForRole(
+            false,
+            false,
+            ORGANIZATION_TYPES.OTHER,
+          );
+
+          assert.deepEqual(result.sort(), [CLASSIFICATION.ANDERE.id]);
         });
 
         test('it should return all non-worship administrative unit and association classification code identifiers', async function (assert) {
@@ -268,7 +283,12 @@ module('Unit | Utility | classification-identifiers', function (hooks) {
                     CLASSIFICATION.WORSHIP_SERVICE.id,
                     CLASSIFICATION.REPRESENTATIVE_BODY.id,
                     // Non administrative units
-                    CLASSIFICATION.CORPORATION_OTHER.id,
+                    CLASSIFICATION.WOONMAATSCHAPPIJ.id,
+                    CLASSIFICATION.INTERLOKALE_VERENIGING.id,
+                    CLASSIFICATION.VERVOERREGIORAAD.id,
+                    CLASSIFICATION.ZORGRAAD.id,
+                    CLASSIFICATION.REGIONAAL_ZORGPLATFORM.id,
+                    CLASSIFICATION.ANDERE.id,
                   ].includes(id),
               )
               .sort(),
@@ -301,7 +321,12 @@ module('Unit | Utility | classification-identifiers', function (hooks) {
                       .id,
                     CLASSIFICATION.WOONZORGVERENIGING_OF_WOONZORGVENNOOTSCHAP
                       .id,
-                    CLASSIFICATION.ASSOCIATION_OTHER.id,
+                    CLASSIFICATION.BOSGROEP.id,
+                    CLASSIFICATION.INTERLOKALE_VERENIGING.id,
+                    CLASSIFICATION.VERVOERREGIORAAD.id,
+                    CLASSIFICATION.ZORGRAAD.id,
+                    CLASSIFICATION.REGIONAAL_ZORGPLATFORM.id,
+                    CLASSIFICATION.ANDERE.id,
                   ].includes(id),
               )
               .sort(),
@@ -327,8 +352,8 @@ module('Unit | Utility | classification-identifiers', function (hooks) {
                   CLASSIFICATION
                     .VERENIGING_OF_VENNOOTSCHAP_VOOR_SOCIALE_DIENSTVERLENING.id,
                   CLASSIFICATION.WOONZORGVERENIGING_OF_WOONZORGVENNOOTSCHAP.id,
-                  CLASSIFICATION.ASSOCIATION_OTHER.id,
-                  CLASSIFICATION.CORPORATION_OTHER.id,
+                  CLASSIFICATION.BOSGROEP.id,
+                  CLASSIFICATION.WOONMAATSCHAPPIJ.id,
                 ].includes(id),
               )
               .sort(),
@@ -355,6 +380,12 @@ module('Unit | Utility | classification-identifiers', function (hooks) {
                     CLASSIFICATION.CENTRAL_WORSHIP_SERVICE.id,
                     CLASSIFICATION.WORSHIP_SERVICE.id,
                     CLASSIFICATION.REPRESENTATIVE_BODY.id,
+                    // Other UI organization types
+                    CLASSIFICATION.INTERLOKALE_VERENIGING.id,
+                    CLASSIFICATION.VERVOERREGIORAAD.id,
+                    CLASSIFICATION.ZORGRAAD.id,
+                    CLASSIFICATION.REGIONAAL_ZORGPLATFORM.id,
+                    CLASSIFICATION.ANDERE.id,
                   ].includes(id),
               )
               .sort(),
@@ -387,8 +418,13 @@ module('Unit | Utility | classification-identifiers', function (hooks) {
                         .id,
                       CLASSIFICATION.WOONZORGVERENIGING_OF_WOONZORGVENNOOTSCHAP
                         .id,
-                      CLASSIFICATION.ASSOCIATION_OTHER.id,
-                      CLASSIFICATION.CORPORATION_OTHER.id,
+                      CLASSIFICATION.BOSGROEP.id,
+                      CLASSIFICATION.WOONMAATSCHAPPIJ.id,
+                      CLASSIFICATION.INTERLOKALE_VERENIGING.id,
+                      CLASSIFICATION.VERVOERREGIORAAD.id,
+                      CLASSIFICATION.ZORGRAAD.id,
+                      CLASSIFICATION.REGIONAAL_ZORGPLATFORM.id,
+                      CLASSIFICATION.ANDERE.id,
                       // Uncreatable administrative units
                       CLASSIFICATION.MUNICIPALITY.id,
                       CLASSIFICATION.PROVINCE.id,
@@ -413,7 +449,7 @@ module('Unit | Utility | classification-identifiers', function (hooks) {
                 CLASSIFICATION
                   .VERENIGING_OF_VENNOOTSCHAP_VOOR_SOCIALE_DIENSTVERLENING.id,
                 CLASSIFICATION.WOONZORGVERENIGING_OF_WOONZORGVENNOOTSCHAP.id,
-                CLASSIFICATION.ASSOCIATION_OTHER.id,
+                CLASSIFICATION.BOSGROEP.id,
               ].sort(),
             );
           });
@@ -426,7 +462,7 @@ module('Unit | Utility | classification-identifiers', function (hooks) {
             );
 
             assert.deepEqual(result.sort(), [
-              CLASSIFICATION.CORPORATION_OTHER.id,
+              CLASSIFICATION.WOONMAATSCHAPPIJ.id,
             ]);
           });
 
@@ -450,7 +486,12 @@ module('Unit | Utility | classification-identifiers', function (hooks) {
                       CLASSIFICATION.WORSHIP_SERVICE.id,
                       CLASSIFICATION.REPRESENTATIVE_BODY.id,
                       // Non administrative units
-                      CLASSIFICATION.CORPORATION_OTHER.id,
+                      CLASSIFICATION.WOONMAATSCHAPPIJ.id,
+                      CLASSIFICATION.INTERLOKALE_VERENIGING.id,
+                      CLASSIFICATION.VERVOERREGIORAAD.id,
+                      CLASSIFICATION.ZORGRAAD.id,
+                      CLASSIFICATION.REGIONAAL_ZORGPLATFORM.id,
+                      CLASSIFICATION.ANDERE.id,
                       // Uncreatable administrative units
                       CLASSIFICATION.MUNICIPALITY.id,
                       CLASSIFICATION.PROVINCE.id,
@@ -487,7 +528,12 @@ module('Unit | Utility | classification-identifiers', function (hooks) {
                         .id,
                       CLASSIFICATION.WOONZORGVERENIGING_OF_WOONZORGVENNOOTSCHAP
                         .id,
-                      CLASSIFICATION.ASSOCIATION_OTHER.id,
+                      CLASSIFICATION.BOSGROEP.id,
+                      CLASSIFICATION.INTERLOKALE_VERENIGING.id,
+                      CLASSIFICATION.VERVOERREGIORAAD.id,
+                      CLASSIFICATION.ZORGRAAD.id,
+                      CLASSIFICATION.REGIONAAL_ZORGPLATFORM.id,
+                      CLASSIFICATION.ANDERE.id,
                       // Uncreatable administrative units
                       CLASSIFICATION.MUNICIPALITY.id,
                       CLASSIFICATION.PROVINCE.id,
@@ -519,8 +565,8 @@ module('Unit | Utility | classification-identifiers', function (hooks) {
                       .id,
                     CLASSIFICATION.WOONZORGVERENIGING_OF_WOONZORGVENNOOTSCHAP
                       .id,
-                    CLASSIFICATION.ASSOCIATION_OTHER.id,
-                    CLASSIFICATION.CORPORATION_OTHER.id,
+                    CLASSIFICATION.BOSGROEP.id,
+                    CLASSIFICATION.WOONMAATSCHAPPIJ.id,
                   ].includes(id),
                 )
                 .sort(),
@@ -547,6 +593,12 @@ module('Unit | Utility | classification-identifiers', function (hooks) {
                       CLASSIFICATION.CENTRAL_WORSHIP_SERVICE.id,
                       CLASSIFICATION.WORSHIP_SERVICE.id,
                       CLASSIFICATION.REPRESENTATIVE_BODY.id,
+                      // Other UI organization types
+                      CLASSIFICATION.INTERLOKALE_VERENIGING.id,
+                      CLASSIFICATION.VERVOERREGIORAAD.id,
+                      CLASSIFICATION.ZORGRAAD.id,
+                      CLASSIFICATION.REGIONAAL_ZORGPLATFORM.id,
+                      CLASSIFICATION.ANDERE.id,
                       // Uncreatable administrative units
                       CLASSIFICATION.MUNICIPALITY.id,
                       CLASSIFICATION.PROVINCE.id,
@@ -592,6 +644,16 @@ module('Unit | Utility | classification-identifiers', function (hooks) {
             true,
             false,
             ORGANIZATION_TYPES.CORPORATION,
+          );
+
+          assert.deepEqual(result.sort(), []);
+        });
+
+        test('it should return all worship other classification code identifiers', async function (assert) {
+          let result = getClassificationIdsForRole(
+            true,
+            false,
+            ORGANIZATION_TYPES.OTHER,
           );
 
           assert.deepEqual(result.sort(), []);
@@ -768,6 +830,12 @@ module('Unit | Utility | classification-identifiers', function (hooks) {
                   CLASSIFICATION.CENTRAL_WORSHIP_SERVICE.id,
                   CLASSIFICATION.WORSHIP_SERVICE.id,
                   CLASSIFICATION.REPRESENTATIVE_BODY.id,
+                  // Other UI organization types
+                  CLASSIFICATION.INTERLOKALE_VERENIGING.id,
+                  CLASSIFICATION.VERVOERREGIORAAD.id,
+                  CLASSIFICATION.ZORGRAAD.id,
+                  CLASSIFICATION.REGIONAAL_ZORGPLATFORM.id,
+                  CLASSIFICATION.ANDERE.id,
                 ].includes(id),
             )
             .sort(),

--- a/tests/unit/utils/organization-type-test.js
+++ b/tests/unit/utils/organization-type-test.js
@@ -43,7 +43,7 @@ module('Unit | Utility | organization-type', function (hooks) {
       CLASSIFICATION.ZIEKENHUISVERENIGING,
       CLASSIFICATION.VERENIGING_OF_VENNOOTSCHAP_VOOR_SOCIALE_DIENSTVERLENING,
       CLASSIFICATION.WOONZORGVERENIGING_OF_WOONZORGVENNOOTSCHAP,
-      CLASSIFICATION.ASSOCIATION_OTHER,
+      CLASSIFICATION.BOSGROEP,
     ].forEach((cl) => {
       test(`it returns the association organization type for ${cl.label}`, async function (assert) {
         const result = getOrganizationTypes(cl.id);
@@ -51,10 +51,29 @@ module('Unit | Utility | organization-type', function (hooks) {
       });
     });
 
-    [CLASSIFICATION.CORPORATION_OTHER].forEach((cl) => {
+    [CLASSIFICATION.WOONMAATSCHAPPIJ].forEach((cl) => {
       test(`it returns the corporation organization type for ${cl.label}`, async function (assert) {
         const result = getOrganizationTypes(cl.id);
         assert.deepEqual(result, [ORGANIZATION_TYPES.CORPORATION]);
+      });
+    });
+
+    [
+      CLASSIFICATION.INTERLOKALE_VERENIGING,
+      CLASSIFICATION.VERVOERREGIORAAD,
+      CLASSIFICATION.ZORGRAAD,
+      CLASSIFICATION.REGIONAAL_ZORGPLATFORM,
+    ].forEach((cl) => {
+      test(`it returns the partnership organization type for ${cl.label}`, async function (assert) {
+        const result = getOrganizationTypes(cl.id);
+        assert.deepEqual(result, [ORGANIZATION_TYPES.PARTNERSHIP]);
+      });
+    });
+
+    [CLASSIFICATION.ANDERE].forEach((cl) => {
+      test(`it returns the other organization type for ${cl.label}`, async function (assert) {
+        const result = getOrganizationTypes(cl.id);
+        assert.deepEqual(result, [ORGANIZATION_TYPES.OTHER]);
       });
     });
 
@@ -73,7 +92,7 @@ module('Unit | Utility | organization-type', function (hooks) {
         CLASSIFICATION.VERENIGING_OF_VENNOOTSCHAP_VOOR_SOCIALE_DIENSTVERLENING
           .id,
         CLASSIFICATION.WOONZORGVERENIGING_OF_WOONZORGVENNOOTSCHAP.id,
-        CLASSIFICATION.ASSOCIATION_OTHER.id,
+        CLASSIFICATION.BOSGROEP.id,
       );
       assert.deepEqual(result, [ORGANIZATION_TYPES.ASSOCIATION]);
     });
@@ -95,7 +114,7 @@ module('Unit | Utility | organization-type', function (hooks) {
     test('it returns the administrative unit and corporation organization types when provided classifications for both', async function (assert) {
       const result = getOrganizationTypes(
         CLASSIFICATION.MUNICIPALITY.id,
-        CLASSIFICATION.CORPORATION_OTHER.id,
+        CLASSIFICATION.WOONMAATSCHAPPIJ.id,
       );
       assert.deepEqual(
         result.sort(),
@@ -109,7 +128,7 @@ module('Unit | Utility | organization-type', function (hooks) {
     test('it returns all organization types when provided classifications for each', async function (assert) {
       const result = getOrganizationTypes(
         CLASSIFICATION.MUNICIPALITY.id,
-        CLASSIFICATION.CORPORATION_OTHER.id,
+        CLASSIFICATION.WOONMAATSCHAPPIJ.id,
         CLASSIFICATION.ZIEKENHUISVERENIGING.id,
       );
       assert.deepEqual(


### PR DESCRIPTION
cf https://github.com/lblod/app-organization-portal/pull/611

- "Regionaal zorgplatform" mirrors Zorgraad: altLabel "Regionale zorgzone", werkingsgebied + KBO required
- "Andere" gets its own group in the "Type organisatie" filter (new `ORGANIZATION_TYPES.OTHER`) and takes over the legacy generic types' behaviour (contact data editable, site type, membership slots)
- `ASSOCIATION_OTHER` / `CORPORATION_OTHER` removed (codes deleted + orgs migrated by the app PR)
- classification-identifiers test expectations were stale since the OP-3794 types landed — updated to the current taxonomy
- note: `requiresContentThemes` (OP-3817) doesn't exclude the new types, so both require an inhoudelijk thema at creation — shout if "Andere" should be exempt
